### PR TITLE
fix: harden weatherbot runtime calls

### DIFF
--- a/messenger.py
+++ b/messenger.py
@@ -32,9 +32,14 @@ FB_PAGE_TOKEN = os.environ.get('FB_PAGE_TOKEN')
 FB_VERIFY_TOKEN = os.environ.get('FB_VERIFY_TOKEN')
 # Weather API
 OPEN_WEATHER_TOKEN = os.environ.get('OPEN_WEATHER_TOKEN')
+REQUEST_TIMEOUT = 10
+
+
+def env_flag(name):
+    return os.environ.get(name, '').lower() in ('1', 'true', 'yes', 'on')
 
 # Setup Bottle Server
-debug(True)
+debug(env_flag('BOTTLE_DEBUG'))
 app = Bottle()
 
 
@@ -94,13 +99,18 @@ def fb_message(sender_id, text):
     qs = 'access_token=' + FB_PAGE_TOKEN
     # Send POST request to messenger
     resp = requests.post('https://graph.facebook.com/me/messages?' + qs,
-                         json=data)
+                         json=data,
+                         timeout=REQUEST_TIMEOUT)
+    resp.raise_for_status()
     return resp.content
 
 
 def get_weather(text):
     qs = {'q': text, 'appid': OPEN_WEATHER_TOKEN}
-    resp = requests.get('http://api.openweathermap.org/data/2.5/weather', qs)
+    resp = requests.get('https://api.openweathermap.org/data/2.5/weather',
+                        params=qs,
+                        timeout=REQUEST_TIMEOUT)
+    resp.raise_for_status()
     data = json.loads(resp.content)
     return str(data['weather'][0]['main'])
 

--- a/messenger.py
+++ b/messenger.py
@@ -66,18 +66,33 @@ def messenger_post():
     Handler for webhook (currently for postback and messages)
     """
     data = request.json
-    if data['object'] == 'page':
-        for entry in data['entry']:
+    if not isinstance(data, dict):
+        return 'Invalid Payload'
+
+    if data.get('object') == 'page':
+        entries = data.get('entry')
+        if not isinstance(entries, list):
+            return None
+
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
             # get all the messages
-            messages = entry['messaging']
-            if messages[0]:
-                # Get the first message
-                message = messages[0]
+            messages = entry.get('messaging')
+            if not isinstance(messages, list):
+                continue
+            for message in messages:
+                if not isinstance(message, dict):
+                    continue
                 # Yay! We got a new message!
                 # We retrieve the Facebook user ID of the sender
-                fb_id = message['sender']['id']
+                sender = message.get('sender') or {}
+                message_body = message.get('message') or {}
+                fb_id = sender.get('id') if isinstance(sender, dict) else None
                 # We retrieve the message content
-                text = message['message']['text']
+                text = message_body.get('text') if isinstance(message_body, dict) else None
+                if not fb_id or not text:
+                    continue
                 # Let's forward the message to the Wit.ai Bot Engine
                 client.run_actions(session_id=fb_id, message=text)
                 # must send back response quickly
@@ -95,11 +110,13 @@ def fb_message(sender_id, text):
         'recipient': {'id': sender_id},
         'message': {'text': text}
     }
-    # Setup the query string with your PAGE TOKEN
-    qs = 'access_token=' + FB_PAGE_TOKEN
+    headers = {
+        'Authorization': 'Bearer ' + FB_PAGE_TOKEN
+    }
     # Send POST request to messenger
-    resp = requests.post('https://graph.facebook.com/me/messages?' + qs,
+    resp = requests.post('https://graph.facebook.com/me/messages',
                          json=data,
+                         headers=headers,
                          timeout=REQUEST_TIMEOUT)
     resp.raise_for_status()
     return resp.content

--- a/wit.py
+++ b/wit.py
@@ -6,6 +6,7 @@ import logging
 WIT_API_HOST = os.getenv('WIT_URL', 'https://api.wit.ai')
 WIT_API_VERSION = os.getenv('WIT_API_VERSION', '20160516')
 DEFAULT_MAX_STEPS = 5
+REQUEST_TIMEOUT = 10
 INTERACTIVE_PROMPT = '> '
 LEARN_MORE = 'Learn more at https://wit.ai/docs/quickstart'
 
@@ -16,6 +17,7 @@ class WitError(Exception):
 
 def req(logger, access_token, meth, path, params, **kwargs):
     full_url = WIT_API_HOST + path
+    timeout = kwargs.pop('timeout', REQUEST_TIMEOUT)
     logger.debug('%s %s %s', meth, full_url, params)
     rsp = requests.request(
         meth,
@@ -25,6 +27,7 @@ def req(logger, access_token, meth, path, params, **kwargs):
             'accept': 'application/vnd.wit.' + WIT_API_VERSION + '+json'
         },
         params=params,
+        timeout=timeout,
         **kwargs
     )
     if rsp.status_code > 200:


### PR DESCRIPTION
## Summary

Hardens outbound requests and production defaults for the legacy Weatherbot service.

## Baseline

The service previously enabled unsafe debug behavior and lacked consistent HTTPS, timeout, and HTTP-error handling boundaries.

## Improvements

Disables debug mode by default, uses HTTPS for weather requests, and adds bounded request failure handling.

## Validation

The original description records compilation and diff checks; the branch was closed without merge and its unavailable dependency-bound tests were not claimed as passing.

## Risk

This closed branch predates the later consolidated Python 3 and webhook-hardening stack.

## Follow-Ups

The maintained implementation and regression coverage were delivered through subsequent merged pull requests.

## Original Description

<details>
<summary>Preserved verbatim</summary>

## Summary
- default Bottle debug mode off unless `BOTTLE_DEBUG` is explicitly enabled
- move OpenWeather API calls to HTTPS
- add bounded timeouts and `raise_for_status()` handling to outbound Messenger and OpenWeather calls
- add a default timeout to the local Wit API helper while preserving caller overrides

## Verification
- `python3 -m py_compile messenger.py wit.py`
- `git diff --check`
- local audit analyzer reports zero current `weatherbot` findings on this branch

`python3 -m unittest -v test_messenger.py` could not run because `bottle` is not installed in this workspace; the existing Messenger/weather tests also exercise live external-style calls.

Closes #2
Closes #3
Closes #5

</details>