### PR TITLE
fix: ignore Messenger echo events

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   media-type requirement on signed Messenger webhook requests.
 - See `docs/plans/2026-06-12-messenger-challenge-plain-text.md` for the
   reflected-XSS-safe verification challenge response contract.
+- See `docs/plans/2026-06-13-messenger-echo-guard.md` for ignoring page echo
+  events without hiding later user messages in the same webhook batch.
 
 ## Contributing
 

--- a/docs/plans/2026-06-13-messenger-echo-guard.md
+++ b/docs/plans/2026-06-13-messenger-echo-guard.md
@@ -1,0 +1,28 @@
+# Messenger Echo Guard
+
+Status: Completed
+
+## Problem
+
+Messenger marks page-generated messages with boolean `message.is_echo`.
+Weatherbot currently forwards those events to Wit as user input, which can
+create reply loops and consume external API capacity. Echoes can also precede
+valid user messages in the same webhook batch.
+
+## Plan
+
+1. Ignore only events whose echo flag is the JSON boolean `true`.
+2. Continue scanning the batch so later user messages still reach Wit.
+3. Add dependency-free and Bottle/WebTest regression coverage.
+4. Preserve existing sender/text normalization and per-message Wit failure
+   isolation.
+
+## Verification
+
+- The focused Bottle/WebTest echo route test passed.
+- The full `make check` gate passed 36 dependency-free contracts and all 18
+  Bottle/WebTest runtime tests under an isolated Python 3.12 environment.
+- The same complete gate passed from an external working directory.
+- Three hostile mutations were rejected: guard removal, early batch return,
+  and arbitrary truthy echo handling.
+- Python compilation and `git diff --check` passed.

--- a/messenger.py
+++ b/messenger.py
@@ -190,6 +190,8 @@ def messenger_text_messages(data):
                 continue
             sender = event.get('sender') or {}
             message = event.get('message') or {}
+            if message.get('is_echo') is True:
+                continue
             fb_id = clean_text_value(sender.get('id'))
             text = clean_text_value(message.get('text'))
             if fb_id and text:

--- a/scripts/check_weatherbot_contracts.py
+++ b/scripts/check_weatherbot_contracts.py
@@ -51,6 +51,9 @@ ROOTED_CLEANUP_PLAN_PATH = (
 MESSENGER_CHALLENGE_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-12-messenger-challenge-plain-text.md"
 )
+MESSENGER_ECHO_PLAN_PATH = (
+    ROOT / "docs" / "plans" / "2026-06-13-messenger-echo-guard.md"
+)
 
 
 class FakeBottle:
@@ -319,6 +322,50 @@ def test_messenger_post_ignores_non_message_events():
 
     assert_equal(body, "ok", "non-message event response")
     assert_equal(calls, [], "non-message events must not call Wit actions")
+
+
+def test_messenger_post_ignores_echoes_and_continues_batch():
+    messenger, request, response, _requests, calls = load_messenger()
+    request.json = {
+        "object": "page",
+        "entry": [{
+            "messaging": [
+                {
+                    "sender": {"id": "page-1"},
+                    "message": {"text": "page reply", "is_echo": True},
+                },
+                {
+                    "sender": {"id": "user-1"},
+                    "message": {"text": "weather in Yountville"},
+                },
+            ]
+        }],
+    }
+    response.status = 200
+
+    body = messenger.messenger_post()
+
+    assert_equal(body, "ok", "Messenger echo event response")
+    assert_equal(calls, [("user-1", "weather in Yountville")], "post-echo Wit call")
+
+
+def test_messenger_post_requires_boolean_true_echo_flag():
+    messenger, request, response, _requests, calls = load_messenger()
+    request.json = {
+        "object": "page",
+        "entry": [{
+            "messaging": [{
+                "sender": {"id": "user-1"},
+                "message": {"text": "weather", "is_echo": "false"},
+            }]
+        }],
+    }
+    response.status = 200
+
+    body = messenger.messenger_post()
+
+    assert_equal(body, "ok", "non-boolean echo flag response")
+    assert_equal(calls, [("user-1", "weather")], "non-boolean echo flag Wit call")
 
 
 def test_messenger_post_routes_text_messages_to_wit():
@@ -737,6 +784,7 @@ def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(MESSENGER_CONTENT_TYPE_PLAN_PATH, "weatherbot Messenger JSON content type")
     assert_completed_plan(ROOTED_CLEANUP_PLAN_PATH, "weatherbot root-independent cleanup")
     assert_completed_plan(MESSENGER_CHALLENGE_PLAN_PATH, "weatherbot Messenger challenge plain text")
+    assert_completed_plan(MESSENGER_ECHO_PLAN_PATH, "weatherbot Messenger echo guard")
 
 
 def test_runtime_dependencies_and_ci_are_pinned():
@@ -858,6 +906,8 @@ def main():
         test_messenger_verification_accepts_matching_token,
         test_messenger_verification_requires_challenge,
         test_messenger_post_ignores_non_message_events,
+        test_messenger_post_ignores_echoes_and_continues_batch,
+        test_messenger_post_requires_boolean_true_echo_flag,
         test_messenger_post_routes_text_messages_to_wit,
         test_messenger_post_isolates_wit_failures_per_message,
         test_messenger_post_propagates_unexpected_action_errors,

--- a/test_messenger.py
+++ b/test_messenger.py
@@ -81,6 +81,35 @@ class TestMessenger(unittest.TestCase):
         self.assertEqual(r.status_int, 200)
         self.assertEqual(r.text, 'ok')
 
+    def test_facebook_echo_is_ignored_before_later_user_message(self):
+        data = {'object': 'page',
+                'entry': [{'messaging': [
+                    {'sender': {'id': 'page-1'},
+                     'message': {'text': 'page reply', 'is_echo': True}},
+                    {'sender': {'id': 'user-2'},
+                     'message': {'text': 'weather in Yountville'}},
+                ]}]}
+
+        class FakeClient(object):
+            def __init__(self):
+                self.calls = []
+
+            def run_actions(self, session_id, message):
+                self.calls.append((session_id, message))
+
+        original_client = messenger.client
+        fake_client = FakeClient()
+        messenger.client = fake_client
+        try:
+            response = self.post_signed_json(data)
+        finally:
+            messenger.client = original_client
+
+        self.assertEqual(response.status_int, 200)
+        self.assertEqual(fake_client.calls, [
+            ('user-2', 'weather in Yountville'),
+        ])
+
     def test_facebook_wit_failure_does_not_block_later_messages(self):
         data = {'object': 'page',
                 'entry': [{'messaging': [


### PR DESCRIPTION
## Summary

Messenger webhook handling now skips events marked with the exact boolean `is_echo: true` while continuing to process later user messages in the same batch. Dependency-free and Bottle/WebTest regression coverage protects the route behavior.

## Baseline

Echo events generated by Messenger could be treated as user input. A leading echo event could also interfere with processing a later valid user message in the same webhook payload.

## Improvements

- skip Messenger events only when `is_echo` is the exact boolean value `true`
- continue scanning the webhook batch after an ignored echo event
- preserve processing for later valid user messages
- add dependency-free contracts and a focused Bottle/WebTest route regression
- record the completed implementation plan evidence

## Validation

- focused Bottle/WebTest echo route
- 36 dependency-free contracts
- 18 runtime tests
- local and external-directory `make check` with isolated Python 3.12 dependencies
- three hostile mutations rejected
- `git diff --check`
- hosted verification succeeded on Python 3.10, 3.12, and 3.14

## Risk

- Messenger payload shape changes could require additional event classification.
- The guard intentionally requires the exact boolean value `true`; string or numeric lookalikes remain outside the echo classification.
- Batch processing must continue after ignored events so valid later messages are not dropped.

## Follow-Ups

- Preserve exact-boolean and later-message regression coverage when webhook parsing changes.
- Add representative malformed and mixed-event payload cases as new Messenger event types are supported.
- Monitor production webhook diagnostics for unexpected echo payload variants without logging message secrets.
