### PR TITLE
Suppress replayed Messenger messages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 2026-06-13
+
+- Added a bounded, thread-safe recent Messenger message-ID cache to suppress
+  duplicate Wit actions from retried webhook deliveries.
+- Released per-message claims after handled Wit failures and unexpected action
+  exceptions while preserving later-message batch processing.
+
 ## 2026-06-12
 
 - Returned Messenger verification challenges as UTF-8 plain text to resolve

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 
 - `make verify` runs syntax checks and dependency-free webhook, Wit action,
   Wit entity normalization, Messenger object validation, Messenger sender/text
-  normalization, Messenger body size, OpenWeather shape, request timeout,
-  outbound API, weather fallback, Wit failure-isolation, and Wit log-privacy
-  contract checks.
+  normalization, Messenger replay suppression and body size, OpenWeather shape,
+  request timeout, outbound API, weather fallback, Wit failure-isolation, and
+  Wit log-privacy contract checks.
 - `make check` runs `make verify` with bytecode cleanup before and after.
 - `python3 scripts/check_weatherbot_contracts.py` runs just the webhook and outbound API contracts.
 - Completed maintenance plans live under `docs/plans` and are checked by
@@ -73,6 +73,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - Expected Wit transport and response failures are isolated to the affected
   Messenger event so later messages in an authenticated batch still run and
   the valid webhook can be acknowledged.
+- Recent non-empty Messenger message IDs are claimed in a bounded process-local
+  cache so retries do not repeat Wit actions; failed actions release claims.
 - `OPEN_WEATHER_TOKEN` configures OpenWeather lookup.
 - `REQUEST_TIMEOUT` optionally overrides outbound request timeout seconds;
   invalid, non-finite, or non-positive values fall back to `5.0`.
@@ -125,6 +127,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   reflected-XSS-safe verification challenge response contract.
 - See `docs/plans/2026-06-13-messenger-echo-guard.md` for ignoring page echo
   events without hiding later user messages in the same webhook batch.
+- See `docs/plans/2026-06-13-messenger-message-replay-guard.md` for bounded
+  process-local retry suppression and per-message failure recovery.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,6 +44,10 @@ parameters and case differences are accepted, while other types return 415
 before signature verification or JSON parsing.
 Messenger GET verification challenges are returned as UTF-8 plain text so
 untrusted challenge values cannot be interpreted as HTML.
+Recent non-empty Messenger message IDs are claimed before Wit actions in a
+bounded process-local cache. Duplicate deliveries are acknowledged without
+repeating actions, while failed actions release their claims for provider
+retries. Claims do not span workers or process restarts.
 
 For web services, APIs, sockets, or scraping workflows, prioritize reports involving authentication bypass, authorization errors, injection, server-side request forgery, unsafe deserialization, credential leakage, data exposure, or denial-of-service conditions. Use test accounts and minimal proof-of-concept traffic only.
 

--- a/VISION.md
+++ b/VISION.md
@@ -19,6 +19,7 @@ Priority:
 - Reject non-page Messenger webhook payloads before Wit action handling
 - Reject blank or non-text Messenger sender IDs before Wit action handling
 - Reject blank Messenger message text before Wit action handling
+- Suppress retried Messenger message IDs before repeating Wit actions
 - Isolate expected Wit failures per Messenger event to avoid batch retry
   amplification after earlier replies
 - Make weather lookup and response flow easy to trace

--- a/docs/plans/2026-06-13-messenger-message-replay-guard.md
+++ b/docs/plans/2026-06-13-messenger-message-replay-guard.md
@@ -1,0 +1,33 @@
+# Messenger Message Replay Guard
+
+Status: In Progress
+
+## Problem
+
+Messenger can retry webhook deliveries with the same message ID. Weatherbot
+currently forwards every valid text event to Wit.ai, so a retry can repeat bot
+actions and outbound replies.
+
+## Plan
+
+1. Parse trimmed non-empty Messenger message IDs with each valid batch message.
+2. Claim IDs before Wit.ai work in a bounded, process-local, thread-safe cache.
+3. Acknowledge duplicate deliveries without repeating Wit.ai actions.
+4. Release claims when Wit.ai work fails, including handled `WitError` failures,
+   so provider retries can recover.
+5. Preserve batch continuation, echo filtering, messages without usable IDs,
+   signature validation, body limits, and malformed-event handling.
+6. Add focused runtime and dependency-free contracts plus mutation coverage.
+7. Document that replay claims do not span workers or process restarts.
+
+## Verification
+
+- Run focused suppression, batch, no-ID, malformed-ID, bounded-eviction, and
+  failure-release tests.
+- Run the full `make check` gate locally and from an external working
+  directory.
+- Reject hostile mutations for parsing, claim ordering, suppression, bounded
+  storage, failure release, locking, and stale plan status.
+- Run Python compilation, `git diff --check`, artifact review, and focused
+  secret review.
+- Do not perform live Messenger, Wit.ai, or OpenWeather requests.

--- a/docs/plans/2026-06-13-messenger-message-replay-guard.md
+++ b/docs/plans/2026-06-13-messenger-message-replay-guard.md
@@ -1,6 +1,6 @@
 # Messenger Message Replay Guard
 
-Status: In Progress
+Status: Completed
 
 ## Problem
 
@@ -22,12 +22,15 @@ actions and outbound replies.
 
 ## Verification
 
-- Run focused suppression, batch, no-ID, malformed-ID, bounded-eviction, and
-  failure-release tests.
-- Run the full `make check` gate locally and from an external working
-  directory.
-- Reject hostile mutations for parsing, claim ordering, suppression, bounded
-  storage, failure release, locking, and stale plan status.
-- Run Python compilation, `git diff --check`, artifact review, and focused
-  secret review.
-- Do not perform live Messenger, Wit.ai, or OpenWeather requests.
+- Seven focused runtime tests and seven focused dependency-free contracts
+  passed for suppression, batch continuation, no-ID and malformed-ID
+  compatibility, bounded eviction, both failure-release branches, and source
+  ordering.
+- The full `make check` gate passed locally and from an external working
+  directory with 43 dependency-free contracts and 25 runtime tests.
+- Ten hostile mutations were rejected for ID parsing and tuple propagation,
+  claim ordering, duplicate suppression, bounded storage, locking, both
+  failure-release branches, and stale plan status.
+- Python compilation, `git diff --check`, artifact review, and focused secret
+  review passed.
+- No live Messenger, Wit.ai, or OpenWeather request was performed.

--- a/messenger.py
+++ b/messenger.py
@@ -22,6 +22,8 @@ import hashlib
 import math
 import os
 import requests
+import threading
+from collections import OrderedDict
 from sys import argv
 from wit import Wit, WitError
 from bottle import Bottle, request, response, debug
@@ -61,6 +63,31 @@ REQUEST_TIMEOUT = positive_float_from_env('REQUEST_TIMEOUT', 5.0)
 debug(truthy_env('WEATHERBOT_DEBUG'))
 app = Bottle()
 MAX_MESSENGER_WEBHOOK_BYTES = 1024 * 1024
+MAX_RECENT_MESSENGER_MESSAGE_IDS = 1024
+
+
+class RecentMessageIds(object):
+    def __init__(self, max_entries):
+        self.max_entries = max_entries
+        self._ids = OrderedDict()
+        self._lock = threading.Lock()
+
+    def claim(self, message_id):
+        with self._lock:
+            if message_id in self._ids:
+                return False
+            self._ids[message_id] = None
+            while len(self._ids) > self.max_entries:
+                self._ids.popitem(last=False)
+            return True
+
+    def release(self, message_id):
+        with self._lock:
+            self._ids.pop(message_id, None)
+
+
+recent_messenger_message_ids = RecentMessageIds(
+    MAX_RECENT_MESSENGER_MESSAGE_IDS)
 
 
 # Facebook Messenger GET Webhook
@@ -141,12 +168,20 @@ def messenger_post():
         response.status = 400
         return 'Invalid payload'
 
-    for fb_id, text in messenger_text_messages(data):
+    for fb_id, text, message_id in messenger_text_messages(data):
+        if message_id and not recent_messenger_message_ids.claim(message_id):
+            continue
         # Let's forward the message to the Wit.ai Bot Engine
         try:
             client.run_actions(session_id=fb_id, message=text)
         except WitError:
+            if message_id:
+                recent_messenger_message_ids.release(message_id)
             continue
+        except Exception:
+            if message_id:
+                recent_messenger_message_ids.release(message_id)
+            raise
 
     # must send back response quickly
     return 'ok'
@@ -172,7 +207,7 @@ def verify_messenger_signature(raw_body, signature, app_secret):
 
 def messenger_text_messages(data):
     """
-    Extract supported Messenger sender/text pairs from a webhook payload.
+    Extract supported Messenger sender/text/message-ID tuples from a payload.
     """
     messages = []
     entries = data.get('entry')
@@ -194,8 +229,9 @@ def messenger_text_messages(data):
                 continue
             fb_id = clean_text_value(sender.get('id'))
             text = clean_text_value(message.get('text'))
+            message_id = clean_text_value(message.get('mid'))
             if fb_id and text:
-                messages.append((fb_id, text))
+                messages.append((fb_id, text, message_id))
     return messages
 
 

--- a/scripts/check_weatherbot_contracts.py
+++ b/scripts/check_weatherbot_contracts.py
@@ -54,6 +54,9 @@ MESSENGER_CHALLENGE_PLAN_PATH = (
 MESSENGER_ECHO_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-13-messenger-echo-guard.md"
 )
+MESSENGER_REPLAY_PLAN_PATH = (
+    ROOT / "docs" / "plans" / "2026-06-13-messenger-message-replay-guard.md"
+)
 
 
 class FakeBottle:
@@ -386,6 +389,140 @@ def test_messenger_post_routes_text_messages_to_wit():
 
     assert_equal(body, "ok", "message event response")
     assert_equal(calls, [("user-1", "weather in Yountville")], "Wit action call")
+
+
+def messenger_payload(message_id="mid-1", text="weather", sender="user-1"):
+    message = {"text": text}
+    if message_id is not None:
+        message["mid"] = message_id
+    return {
+        "object": "page",
+        "entry": [{"messaging": [{"sender": {"id": sender}, "message": message}]}],
+    }
+
+
+def test_messenger_post_suppresses_replayed_message_ids():
+    messenger, request, _response, _requests, calls = load_messenger()
+    request.json = messenger_payload("mid-replayed")
+
+    assert_equal(messenger.messenger_post(), "ok", "first Messenger delivery")
+    assert_equal(messenger.messenger_post(), "ok", "replayed Messenger delivery")
+
+    assert_equal(calls, [("user-1", "weather")], "replayed message ID Wit calls")
+
+
+def test_messenger_post_duplicate_batch_item_does_not_block_later_message():
+    messenger, request, _response, _requests, calls = load_messenger()
+    request.json = {
+        "object": "page",
+        "entry": [{"messaging": [
+            {"sender": {"id": "user-1"}, "message": {"mid": "mid-1", "text": "first"}},
+            {"sender": {"id": "user-1"}, "message": {"mid": "mid-1", "text": "first"}},
+            {"sender": {"id": "user-2"}, "message": {"mid": "mid-2", "text": "second"}},
+        ]}],
+    }
+
+    assert_equal(messenger.messenger_post(), "ok", "duplicate batch response")
+    assert_equal(
+        calls,
+        [("user-1", "first"), ("user-2", "second")],
+        "duplicate batch Wit calls",
+    )
+
+
+def test_messenger_post_releases_claim_after_wit_failure():
+    messenger, request, _response, _requests, _calls = load_messenger()
+    processed = []
+
+    def run_actions(session_id, message):
+        processed.append((session_id, message))
+        if len(processed) == 1:
+            raise messenger.WitError("Wit request failed.")
+
+    messenger.client = types.SimpleNamespace(run_actions=run_actions)
+    request.json = messenger_payload("mid-retry")
+
+    assert_equal(messenger.messenger_post(), "ok", "failed Messenger delivery")
+    assert_equal(messenger.messenger_post(), "ok", "retried Messenger delivery")
+    assert_equal(
+        processed,
+        [("user-1", "weather"), ("user-1", "weather")],
+        "failed Wit claim release",
+    )
+
+
+def test_messenger_post_releases_claim_after_unexpected_failure():
+    messenger, request, _response, _requests, _calls = load_messenger()
+    processed = []
+
+    def run_actions(session_id, message):
+        processed.append((session_id, message))
+        if len(processed) == 1:
+            raise RuntimeError("programming error")
+
+    messenger.client = types.SimpleNamespace(run_actions=run_actions)
+    request.json = messenger_payload("mid-retry")
+
+    try:
+        messenger.messenger_post()
+    except RuntimeError as error:
+        assert_equal(str(error), "programming error", "unexpected action error")
+    else:
+        raise AssertionError("unexpected action errors must propagate")
+
+    assert_equal(messenger.messenger_post(), "ok", "retry after unexpected failure")
+    assert_equal(
+        processed,
+        [("user-1", "weather"), ("user-1", "weather")],
+        "unexpected failure claim release",
+    )
+
+
+def test_messenger_post_preserves_missing_and_malformed_ids():
+    for message_id in (None, {"not": "text"}):
+        messenger, request, _response, _requests, calls = load_messenger()
+        request.json = messenger_payload(message_id)
+
+        messenger.messenger_post()
+        messenger.messenger_post()
+
+        assert_equal(
+            calls,
+            [("user-1", "weather"), ("user-1", "weather")],
+            "message ID compatibility {0!r}".format(message_id),
+        )
+
+
+def test_recent_message_ids_evicts_oldest_claim_at_bound():
+    messenger, _request, _response, _requests, _calls = load_messenger()
+    recent = messenger.RecentMessageIds(2)
+
+    assert_true(recent.claim("mid-1"), "first replay claim")
+    assert_true(recent.claim("mid-2"), "second replay claim")
+    assert_true(recent.claim("mid-3"), "third replay claim")
+    assert_true(not recent.claim("mid-3"), "newest claim must remain protected")
+    assert_true(recent.claim("mid-1"), "oldest claim must be evicted")
+
+
+def test_messenger_replay_source_contracts():
+    source = (ROOT / "messenger.py").read_text(encoding="utf-8")
+    for contract in (
+            "MAX_RECENT_MESSENGER_MESSAGE_IDS = 1024",
+            "class RecentMessageIds(object):",
+            "self._lock = threading.Lock()",
+            "self._ids.popitem(last=False)",
+            "message_id = clean_text_value(message.get('mid'))",
+            "recent_messenger_message_ids.claim(message_id)",
+            "recent_messenger_message_ids.release(message_id)"):
+        assert_true(contract in source, "missing Messenger replay contract {0}".format(contract))
+
+    claim_position = source.index("recent_messenger_message_ids.claim(message_id)")
+    action_position = source.index("client.run_actions(session_id=fb_id, message=text)")
+    release_position = source.index("recent_messenger_message_ids.release(message_id)")
+    assert_true(
+        claim_position < action_position < release_position,
+        "claim, Wit action, and failure release must stay ordered",
+    )
 
 
 def test_messenger_post_isolates_wit_failures_per_message():
@@ -785,6 +922,7 @@ def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(ROOTED_CLEANUP_PLAN_PATH, "weatherbot root-independent cleanup")
     assert_completed_plan(MESSENGER_CHALLENGE_PLAN_PATH, "weatherbot Messenger challenge plain text")
     assert_completed_plan(MESSENGER_ECHO_PLAN_PATH, "weatherbot Messenger echo guard")
+    assert_completed_plan(MESSENGER_REPLAY_PLAN_PATH, "weatherbot Messenger replay guard")
 
 
 def test_runtime_dependencies_and_ci_are_pinned():
@@ -909,6 +1047,13 @@ def main():
         test_messenger_post_ignores_echoes_and_continues_batch,
         test_messenger_post_requires_boolean_true_echo_flag,
         test_messenger_post_routes_text_messages_to_wit,
+        test_messenger_post_suppresses_replayed_message_ids,
+        test_messenger_post_duplicate_batch_item_does_not_block_later_message,
+        test_messenger_post_releases_claim_after_wit_failure,
+        test_messenger_post_releases_claim_after_unexpected_failure,
+        test_messenger_post_preserves_missing_and_malformed_ids,
+        test_recent_message_ids_evicts_oldest_claim_at_bound,
+        test_messenger_replay_source_contracts,
         test_messenger_post_isolates_wit_failures_per_message,
         test_messenger_post_propagates_unexpected_action_errors,
         test_messenger_post_ignores_blank_message_text,

--- a/test_messenger.py
+++ b/test_messenger.py
@@ -38,6 +38,8 @@ class TestMessenger(unittest.TestCase):
         self.user_id = '1305664346125260'
         self.challenge = '123'
         self.location = 'Yountville'
+        messenger.recent_messenger_message_ids = messenger.RecentMessageIds(
+            messenger.MAX_RECENT_MESSENGER_MESSAGE_IDS)
 
     def test_facebook_webhook(self):
         """
@@ -109,6 +111,132 @@ class TestMessenger(unittest.TestCase):
         self.assertEqual(fake_client.calls, [
             ('user-2', 'weather in Yountville'),
         ])
+
+    def test_facebook_replayed_message_id_runs_actions_once(self):
+        class FakeClient(object):
+            def __init__(self):
+                self.calls = []
+
+            def run_actions(self, session_id, message):
+                self.calls.append((session_id, message))
+
+        original_client = messenger.client
+        fake_client = FakeClient()
+        messenger.client = fake_client
+        try:
+            first = self.post_signed_json(self.data)
+            replay = self.post_signed_json(self.data)
+        finally:
+            messenger.client = original_client
+
+        self.assertEqual(first.status_int, 200)
+        self.assertEqual(replay.status_int, 200)
+        self.assertEqual(fake_client.calls, [(self.user_id, 'hey')])
+
+    def test_facebook_duplicate_batch_item_does_not_block_later_message(self):
+        data = {'object': 'page',
+                'entry': [{'messaging': [
+                    {'sender': {'id': 'user-1'},
+                     'message': {'mid': 'mid-1', 'text': 'first'}},
+                    {'sender': {'id': 'user-1'},
+                     'message': {'mid': 'mid-1', 'text': 'first'}},
+                    {'sender': {'id': 'user-2'},
+                     'message': {'mid': 'mid-2', 'text': 'second'}},
+                ]}]}
+
+        calls = []
+        original_client = messenger.client
+        messenger.client = mock.Mock(
+            run_actions=lambda session_id, message: calls.append((session_id, message)))
+        try:
+            response = self.post_signed_json(data)
+        finally:
+            messenger.client = original_client
+
+        self.assertEqual(response.status_int, 200)
+        self.assertEqual(calls, [('user-1', 'first'), ('user-2', 'second')])
+
+    def test_facebook_wit_failure_releases_message_claim_for_retry(self):
+        calls = []
+
+        def run_actions(session_id, message):
+            calls.append((session_id, message))
+            if len(calls) == 1:
+                raise messenger.WitError('Wit request failed.')
+
+        original_client = messenger.client
+        messenger.client = mock.Mock(run_actions=run_actions)
+        try:
+            first = self.post_signed_json(self.data)
+            retry = self.post_signed_json(self.data)
+        finally:
+            messenger.client = original_client
+
+        self.assertEqual(first.status_int, 200)
+        self.assertEqual(retry.status_int, 200)
+        self.assertEqual(calls, [(self.user_id, 'hey'), (self.user_id, 'hey')])
+
+    def test_facebook_unexpected_failure_releases_message_claim_for_retry(self):
+        calls = []
+
+        def run_actions(session_id, message):
+            calls.append((session_id, message))
+            if len(calls) == 1:
+                raise RuntimeError('programming error')
+
+        original_client = messenger.client
+        messenger.client = mock.Mock(run_actions=run_actions)
+        try:
+            failed = self.post_signed_json(self.data, expect_errors=True)
+            retry = self.post_signed_json(self.data)
+        finally:
+            messenger.client = original_client
+
+        self.assertEqual(failed.status_int, 500)
+        self.assertEqual(retry.status_int, 200)
+        self.assertEqual(calls, [(self.user_id, 'hey'), (self.user_id, 'hey')])
+
+    def test_facebook_messages_without_ids_preserve_compatibility(self):
+        data = {'object': 'page',
+                'entry': [{'messaging': [{'sender': {'id': 'user-1'},
+                                          'message': {'text': 'weather'}}]}]}
+        calls = []
+        original_client = messenger.client
+        messenger.client = mock.Mock(
+            run_actions=lambda session_id, message: calls.append((session_id, message)))
+        try:
+            self.post_signed_json(data)
+            self.post_signed_json(data)
+        finally:
+            messenger.client = original_client
+
+        self.assertEqual(calls, [('user-1', 'weather'), ('user-1', 'weather')])
+
+    def test_facebook_malformed_message_ids_preserve_compatibility(self):
+        data = {'object': 'page',
+                'entry': [{'messaging': [{'sender': {'id': 'user-1'},
+                                          'message': {'mid': {'bad': 'id'},
+                                                      'text': 'weather'}}]}]}
+        calls = []
+        original_client = messenger.client
+        messenger.client = mock.Mock(
+            run_actions=lambda session_id, message: calls.append((session_id, message)))
+        try:
+            self.post_signed_json(data)
+            self.post_signed_json(data)
+        finally:
+            messenger.client = original_client
+
+        self.assertEqual(calls, [('user-1', 'weather'), ('user-1', 'weather')])
+
+    def test_recent_message_ids_evict_oldest_claim_at_bound(self):
+        recent = messenger.RecentMessageIds(2)
+
+        self.assertTrue(recent.claim('mid-1'))
+        self.assertTrue(recent.claim('mid-2'))
+        self.assertTrue(recent.claim('mid-3'))
+        self.assertFalse(recent.claim('mid-3'))
+        self.assertTrue(recent.claim('mid-1'))
 
     def test_facebook_wit_failure_does_not_block_later_messages(self):
         data = {'object': 'page',


### PR DESCRIPTION
## Summary

- claim non-empty Messenger message IDs before per-message Wit actions
- suppress duplicate deliveries with a bounded, thread-safe process-local cache
- release only the affected claim after handled Wit failures or unexpected action exceptions
- preserve batch continuation, no-ID/malformed-ID compatibility, and echo filtering

## Baseline

Repeated delivery of a Messenger event with the same non-empty message ID could invoke the per-message Wit action more than once because the process had no bounded replay claim before action dispatch.

## Improvements

- claim eligible message IDs before invoking Wit actions
- suppress duplicate deliveries with a bounded, thread-safe process-local cache
- release only the affected claim after handled Wit failures or unexpected action exceptions
- preserve batch continuation, missing or malformed ID compatibility, and echo filtering

## Validation

- seven focused runtime and seven focused dependency-free tests passed
- `make check` passed locally and from an external working directory
- 43 dependency-free contracts and 25 runtime tests passed
- ten hostile mutations rejected
- Python compilation, `git diff --check`, artifact review, and focused secret review passed

## Risk

Replay claims are intentionally bounded and process-local. They do not coordinate across workers or survive process restarts. Validation used no live Messenger, Wit.ai, or OpenWeather request.

## Follow-Ups

Use a shared durable idempotency store if replay suppression must span workers or process restarts; that distributed behavior is outside this PR.
