### PR TITLE
fix: bound Messenger batch processing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## 2026-06-13
 
+- Capped each signed Messenger webhook at 20 valid Wit action messages while
+  preserving payload order and per-message replay handling.
+- Ignored malformed nested sender and message values without hiding later
+  valid events in the same batch.
 - Added a bounded, thread-safe recent Messenger message-ID cache to suppress
   duplicate Wit actions from retried webhook deliveries.
 - Released per-message claims after handled Wit failures and unexpected action

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   the valid webhook can be acknowledged.
 - Recent non-empty Messenger message IDs are claimed in a bounded process-local
   cache so retries do not repeat Wit actions; failed actions release claims.
+- Signed Messenger batches process at most 20 valid user messages in payload
+  order; malformed nested events and echoes do not hide later valid messages.
 - `OPEN_WEATHER_TOKEN` configures OpenWeather lookup.
 - `REQUEST_TIMEOUT` optionally overrides outbound request timeout seconds;
   invalid, non-finite, or non-positive values fall back to `5.0`.
@@ -129,6 +131,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   events without hiding later user messages in the same webhook batch.
 - See `docs/plans/2026-06-13-messenger-message-replay-guard.md` for bounded
   process-local retry suppression and per-message failure recovery.
+- See `docs/plans/2026-06-13-messenger-batch-processing-bound.md` for ordered,
+  bounded Messenger batch handling and malformed-event isolation.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,6 +48,9 @@ Recent non-empty Messenger message IDs are claimed before Wit actions in a
 bounded process-local cache. Duplicate deliveries are acknowledged without
 repeating actions, while failed actions release their claims for provider
 retries. Claims do not span workers or process restarts.
+Each signed webhook processes at most 20 valid Messenger user messages in
+payload order. Malformed nested sender or message values are ignored without
+preventing later valid events from reaching Wit.
 
 For web services, APIs, sockets, or scraping workflows, prioritize reports involving authentication bypass, authorization errors, injection, server-side request forgery, unsafe deserialization, credential leakage, data exposure, or denial-of-service conditions. Use test accounts and minimal proof-of-concept traffic only.
 

--- a/VISION.md
+++ b/VISION.md
@@ -20,6 +20,7 @@ Priority:
 - Reject blank or non-text Messenger sender IDs before Wit action handling
 - Reject blank Messenger message text before Wit action handling
 - Suppress retried Messenger message IDs before repeating Wit actions
+- Process Messenger message batches in order with a fixed per-webhook cap
 - Isolate expected Wit failures per Messenger event to avoid batch retry
   amplification after earlier replies
 - Make weather lookup and response flow easy to trace

--- a/docs/plans/2026-06-13-messenger-batch-processing-bound.md
+++ b/docs/plans/2026-06-13-messenger-batch-processing-bound.md
@@ -1,0 +1,48 @@
+# Bound Messenger Batch Processing
+
+Status: Planned
+
+## Problem
+
+Weatherbot processes every valid Messenger event in a webhook payload. A
+signed payload can therefore amplify into an unbounded number of Wit.ai action
+calls within the existing 1 MiB body limit. The extractor also assumes nested
+`sender` and `message` values are objects, so malformed later events can abort
+the whole batch.
+
+## Requirements
+
+1. Process no more than 20 valid user messages from one webhook in payload
+   order.
+2. Ignore malformed entries, event arrays, events, sender objects, message
+   objects, and boolean-true echoes without hiding later valid messages.
+3. Preserve per-message replay claims, ID-less compatibility, Wit failure
+   isolation, and unexpected-exception propagation.
+4. Add executable and dependency-free coverage plus hostile mutations for the
+   cap, ordering, malformed nested events, replay continuation, and failure
+   cleanup.
+5. Document the operational boundary and keep all live provider calls mocked.
+
+## Implementation
+
+- Add a named per-webhook message cap beside the existing body and replay
+  limits.
+- Validate nested event shapes before field access and return as soon as the
+  valid-message cap is reached.
+- Extend runtime tests, portable contracts, maintenance documentation, and
+  completed-plan registration without new dependencies.
+
+## Verification
+
+- Run focused batch tests and hostile mutations under explicit timeouts.
+- Run local and external-working-directory `make check` under explicit
+  timeouts.
+- Audit Python syntax, workflow YAML, intended paths, generated artifacts,
+  conflict markers, whitespace, and changed-line credential patterns.
+- Do not use live Messenger, Wit.ai, or OpenWeather credentials or requests.
+
+## Scope Boundaries
+
+- Do not add queues, parallel processing, distributed replay storage, retries,
+  or provider API changes.
+- Do not merge or close any pull request without explicit owner authorization.

--- a/docs/plans/2026-06-13-messenger-batch-processing-bound.md
+++ b/docs/plans/2026-06-13-messenger-batch-processing-bound.md
@@ -1,6 +1,6 @@
 # Bound Messenger Batch Processing
 
-Status: Planned
+Status: Completed
 
 ## Problem
 
@@ -34,12 +34,23 @@ the whole batch.
 
 ## Verification
 
-- Run focused batch tests and hostile mutations under explicit timeouts.
-- Run local and external-working-directory `make check` under explicit
-  timeouts.
-- Audit Python syntax, workflow YAML, intended paths, generated artifacts,
-  conflict markers, whitespace, and changed-line credential patterns.
-- Do not use live Messenger, Wit.ai, or OpenWeather credentials or requests.
+- Five focused dependency-free contracts passed for malformed nested events,
+  the valid-message cap, replay continuation, Wit failure isolation, and source
+  requirements.
+- Three focused Bottle/WebTest cases passed for malformed nested events, the
+  per-webhook cap, and duplicate replay continuation.
+- Eight hostile mutations covering cap inflation/removal, nested-shape guard
+  removal, replay short-circuiting, both failure-release paths, and missing
+  runtime tests were rejected.
+- Final local and external-working-directory `make check` runs passed under
+  explicit three-minute timeouts with 46 dependency-free contracts and 27
+  runtime tests.
+- A fresh pinned Python 3.12 environment passed `pip check` and both full gates
+  with the machine-wide `PYTHONPATH` removed.
+- Python syntax, workflow YAML, intended paths, generated artifacts, conflict
+  markers, whitespace, and changed-line credential patterns are included in
+  the final audit.
+- No live Messenger, Wit.ai, or OpenWeather credentials or requests were used.
 
 ## Scope Boundaries
 

--- a/messenger.py
+++ b/messenger.py
@@ -64,6 +64,7 @@ debug(truthy_env('WEATHERBOT_DEBUG'))
 app = Bottle()
 MAX_MESSENGER_WEBHOOK_BYTES = 1024 * 1024
 MAX_RECENT_MESSENGER_MESSAGE_IDS = 1024
+MAX_MESSENGER_MESSAGES_PER_WEBHOOK = 20
 
 
 class RecentMessageIds(object):
@@ -223,8 +224,10 @@ def messenger_text_messages(data):
         for event in events:
             if not isinstance(event, dict):
                 continue
-            sender = event.get('sender') or {}
-            message = event.get('message') or {}
+            sender = event.get('sender')
+            message = event.get('message')
+            if not isinstance(sender, dict) or not isinstance(message, dict):
+                continue
             if message.get('is_echo') is True:
                 continue
             fb_id = clean_text_value(sender.get('id'))
@@ -232,6 +235,8 @@ def messenger_text_messages(data):
             message_id = clean_text_value(message.get('mid'))
             if fb_id and text:
                 messages.append((fb_id, text, message_id))
+                if len(messages) >= MAX_MESSENGER_MESSAGES_PER_WEBHOOK:
+                    return messages
     return messages
 
 

--- a/scripts/check_weatherbot_contracts.py
+++ b/scripts/check_weatherbot_contracts.py
@@ -57,6 +57,9 @@ MESSENGER_ECHO_PLAN_PATH = (
 MESSENGER_REPLAY_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-13-messenger-message-replay-guard.md"
 )
+MESSENGER_BATCH_PLAN_PATH = (
+    ROOT / "docs" / "plans" / "2026-06-13-messenger-batch-processing-bound.md"
+)
 
 
 class FakeBottle:
@@ -352,6 +355,58 @@ def test_messenger_post_ignores_echoes_and_continues_batch():
     assert_equal(calls, [("user-1", "weather in Yountville")], "post-echo Wit call")
 
 
+def test_messenger_post_ignores_malformed_nested_events_and_continues_batch():
+    messenger, request, response, _requests, calls = load_messenger()
+    request.json = {
+        "object": "page",
+        "entry": [{
+            "messaging": [
+                {"sender": ["malformed"], "message": {"text": "ignored"}},
+                {"sender": {"id": "ignored"}, "message": ["malformed"]},
+                {"sender": {"id": "user-2"}, "message": {"text": "weather"}},
+            ]
+        }],
+    }
+    response.status = 200
+
+    body = messenger.messenger_post()
+
+    assert_equal(response.status, 200, "malformed nested batch status")
+    assert_equal(body, "ok", "malformed nested batch response")
+    assert_equal(calls, [("user-2", "weather")], "malformed nested batch Wit calls")
+
+
+def test_messenger_post_caps_valid_message_batch():
+    messenger, request, response, _requests, calls = load_messenger()
+    request.json = {
+        "object": "page",
+        "entry": [{
+            "messaging": [
+                {
+                    "sender": {"id": "user-{0}".format(index)},
+                    "message": {
+                        "mid": "batch-{0}".format(index),
+                        "text": "weather-{0}".format(index),
+                    },
+                }
+                for index in range(messenger.MAX_MESSENGER_MESSAGES_PER_WEBHOOK + 1)
+            ]
+        }],
+    }
+    response.status = 200
+
+    body = messenger.messenger_post()
+
+    assert_equal(response.status, 200, "capped Messenger batch status")
+    assert_equal(body, "ok", "capped Messenger batch response")
+    assert_equal(
+        len(calls),
+        messenger.MAX_MESSENGER_MESSAGES_PER_WEBHOOK,
+        "capped Messenger batch Wit call count",
+    )
+    assert_equal(calls[-1], ("user-19", "weather-19"), "capped Messenger final call")
+
+
 def test_messenger_post_requires_boolean_true_echo_flag():
     messenger, request, response, _requests, calls = load_messenger()
     request.json = {
@@ -523,6 +578,21 @@ def test_messenger_replay_source_contracts():
         claim_position < action_position < release_position,
         "claim, Wit action, and failure release must stay ordered",
     )
+
+
+def test_messenger_batch_source_contracts():
+    source = (ROOT / "messenger.py").read_text(encoding="utf-8")
+    runtime_tests = (ROOT / "test_messenger.py").read_text(encoding="utf-8")
+    for contract in (
+            "MAX_MESSENGER_MESSAGES_PER_WEBHOOK = 20",
+            "if not isinstance(sender, dict) or not isinstance(message, dict):",
+            "if len(messages) >= MAX_MESSENGER_MESSAGES_PER_WEBHOOK:",
+            "return messages"):
+        assert_true(contract in source, "missing Messenger batch contract {0}".format(contract))
+    for test_name in (
+            "test_facebook_malformed_nested_events_do_not_hide_later_messages",
+            "test_facebook_caps_valid_message_batch"):
+        assert_true(test_name in runtime_tests, "missing Messenger batch runtime test {0}".format(test_name))
 
 
 def test_messenger_post_isolates_wit_failures_per_message():
@@ -923,6 +993,7 @@ def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(MESSENGER_CHALLENGE_PLAN_PATH, "weatherbot Messenger challenge plain text")
     assert_completed_plan(MESSENGER_ECHO_PLAN_PATH, "weatherbot Messenger echo guard")
     assert_completed_plan(MESSENGER_REPLAY_PLAN_PATH, "weatherbot Messenger replay guard")
+    assert_completed_plan(MESSENGER_BATCH_PLAN_PATH, "weatherbot Messenger batch processing bound")
 
 
 def test_runtime_dependencies_and_ci_are_pinned():
@@ -1045,6 +1116,8 @@ def main():
         test_messenger_verification_requires_challenge,
         test_messenger_post_ignores_non_message_events,
         test_messenger_post_ignores_echoes_and_continues_batch,
+        test_messenger_post_ignores_malformed_nested_events_and_continues_batch,
+        test_messenger_post_caps_valid_message_batch,
         test_messenger_post_requires_boolean_true_echo_flag,
         test_messenger_post_routes_text_messages_to_wit,
         test_messenger_post_suppresses_replayed_message_ids,
@@ -1054,6 +1127,7 @@ def main():
         test_messenger_post_preserves_missing_and_malformed_ids,
         test_recent_message_ids_evicts_oldest_claim_at_bound,
         test_messenger_replay_source_contracts,
+        test_messenger_batch_source_contracts,
         test_messenger_post_isolates_wit_failures_per_message,
         test_messenger_post_propagates_unexpected_action_errors,
         test_messenger_post_ignores_blank_message_text,

--- a/test_messenger.py
+++ b/test_messenger.py
@@ -112,6 +112,48 @@ class TestMessenger(unittest.TestCase):
             ('user-2', 'weather in Yountville'),
         ])
 
+    def test_facebook_malformed_nested_events_do_not_hide_later_messages(self):
+        data = {'object': 'page',
+                'entry': [{'messaging': [
+                    {'sender': ['malformed'], 'message': {'text': 'ignored'}},
+                    {'sender': {'id': 'ignored'}, 'message': ['malformed']},
+                    {'sender': {'id': 'user-2'},
+                     'message': {'text': 'weather in Yountville'}},
+                ]}]}
+        calls = []
+        original_client = messenger.client
+        messenger.client = mock.Mock(
+            run_actions=lambda session_id, message: calls.append((session_id, message)))
+        try:
+            response = self.post_signed_json(data)
+        finally:
+            messenger.client = original_client
+
+        self.assertEqual(response.status_int, 200)
+        self.assertEqual(calls, [('user-2', 'weather in Yountville')])
+
+    def test_facebook_caps_valid_message_batch(self):
+        events = [
+            {'sender': {'id': 'user-{0}'.format(index)},
+             'message': {'mid': 'batch-{0}'.format(index),
+                         'text': 'weather-{0}'.format(index)}}
+            for index in range(messenger.MAX_MESSENGER_MESSAGES_PER_WEBHOOK + 1)
+        ]
+        calls = []
+        original_client = messenger.client
+        messenger.client = mock.Mock(
+            run_actions=lambda session_id, message: calls.append((session_id, message)))
+        try:
+            response = self.post_signed_json(
+                {'object': 'page', 'entry': [{'messaging': events}]})
+        finally:
+            messenger.client = original_client
+
+        self.assertEqual(response.status_int, 200)
+        self.assertEqual(len(calls), messenger.MAX_MESSENGER_MESSAGES_PER_WEBHOOK)
+        self.assertEqual(calls[0], ('user-0', 'weather-0'))
+        self.assertEqual(calls[-1], ('user-19', 'weather-19'))
+
     def test_facebook_replayed_message_id_runs_actions_once(self):
         class FakeClient(object):
             def __init__(self):


### PR DESCRIPTION
## Summary

Signed Messenger webhook batches can no longer amplify into unbounded Wit.ai action calls. Weatherbot processes at most 20 valid user messages in payload order, while malformed nested sender/message values and page echoes are skipped without hiding later valid events.

## Baseline

This PR is stacked on `lfg/weatherbot-messenger-replay-guard-20260613`. Per-message replay protection already guarded duplicate delivery, but a single valid signed webhook payload could contain an unbounded number of processable messages.

## Improvements

- Process at most 20 valid user messages from each signed Messenger webhook payload.
- Preserve payload ordering for accepted messages.
- Skip malformed nested sender or message values and page echoes without suppressing later valid events.
- Keep replay claims isolated per message: duplicates continue to later messages and handled Wit.ai failures release only their own claim.
- Continue propagating unexpected exceptions after releasing the failing message's claim.

## Validation

- A clean pinned Python 3.12 environment was used with machine-wide `PYTHONPATH` removed.
- Local and external `make check` passed under three-minute timeouts.
- Forty-six dependency-free contracts and twenty-seven Bottle/WebTest runtime tests passed.
- Eight hostile batch and replay-cleanup mutations were rejected.
- `pip check` found no broken requirements.
- Workflow YAML, diff, artifact, conflict-marker, and changed-line credential audits passed.
- Exact-head checks passed on Python 3.10, 3.12, and 3.14.
- No live Messenger, Wit.ai, or OpenWeather requests were used.

## Risk

Valid messages after the twentieth accepted event are intentionally deferred or dropped with the remainder of that webhook delivery. The limit constrains provider-call amplification but does not replace upstream request-size controls or distributed rate limiting.

## Follow-Ups

Review and merge the stacked replay-guard and batch-bound branches in order. Monitor real webhook batch sizes before changing the fixed limit.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
