### PR TITLE
fix: protect Make root from overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PYTHON ?= python3
-ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
 PYTHON_FILES = messenger.py wit.py test_messenger.py scripts/check_weatherbot_contracts.py
 

--- a/docs/plans/2026-06-14-make-root-override-protection.md
+++ b/docs/plans/2026-06-14-make-root-override-protection.md
@@ -1,0 +1,30 @@
+# Protect the Make Repository Root from Overrides
+
+## Status: Planned
+
+## Context
+
+The Makefile-derived root anchors Messenger contracts, runtime tests, and
+cleanup, but an ordinary assignment can be replaced from the command line and
+redirect verification away from the reviewed checkout.
+
+## Requirements
+
+- Protect the Makefile-derived root with GNU Make's `override` directive.
+- Preserve the configurable Python command and final rooted cleanup.
+- Require exact protected root and Python lines in the dependency-free checker.
+- Pass local, external-directory, and hostile-root full pinned gates.
+- Reject root, checker, Python override, cleanup, and plan regressions.
+- Preserve Messenger, Wit.ai, weather-provider, workflow, and dependency behavior.
+
+## Verification Plan
+
+- focused hosted/Makefile contract and Python compilation
+- bounded local, external-directory, and hostile-root `make check`
+- focused mutations and pinned dependency integrity
+- workflow YAML, artifact, whitespace, and changed-line credential audits
+
+## Scope Boundaries
+
+- Do not alter runtime behavior, dependencies, workflows, or provider policy.
+- Do not merge or close stacked pull requests without owner authorization.

--- a/docs/plans/2026-06-14-make-root-override-protection.md
+++ b/docs/plans/2026-06-14-make-root-override-protection.md
@@ -1,6 +1,6 @@
 # Protect the Make Repository Root from Overrides
 
-## Status: Planned
+## Status: Completed
 
 ## Context
 
@@ -28,3 +28,20 @@ redirect verification away from the reviewed checkout.
 
 - Do not alter runtime behavior, dependencies, workflows, or provider policy.
 - Do not merge or close stacked pull requests without owner authorization.
+
+## Work Completed
+
+- Protected the Makefile-derived root while preserving the Python override and
+  rooted final cleanup.
+- Added exact-line checker contracts and registered this completed plan.
+
+## Verification
+
+- Python compilation and the focused hosted/Makefile contract passed.
+- Local, absolute-Makefile external-directory, and hostile-root `make check`
+  runs passed under 300-second timeouts with 46 dependency-free contracts and
+  27 runtime tests.
+- Nine hostile root, checker, Python override, cleanup, and plan-status
+  mutations were rejected.
+- `uv pip check` passed all 12 packages in the fresh pinned Python 3.12
+  environment; YAML, artifact, whitespace, and credential audits passed.

--- a/scripts/check_weatherbot_contracts.py
+++ b/scripts/check_weatherbot_contracts.py
@@ -60,6 +60,9 @@ MESSENGER_REPLAY_PLAN_PATH = (
 MESSENGER_BATCH_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-13-messenger-batch-processing-bound.md"
 )
+MAKE_ROOT_PROTECTION_PLAN_PATH = (
+    ROOT / "docs" / "plans" / "2026-06-14-make-root-override-protection.md"
+)
 
 
 class FakeBottle:
@@ -994,6 +997,7 @@ def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(MESSENGER_ECHO_PLAN_PATH, "weatherbot Messenger echo guard")
     assert_completed_plan(MESSENGER_REPLAY_PLAN_PATH, "weatherbot Messenger replay guard")
     assert_completed_plan(MESSENGER_BATCH_PLAN_PATH, "weatherbot Messenger batch processing bound")
+    assert_completed_plan(MAKE_ROOT_PROTECTION_PLAN_PATH, "weatherbot Make root override protection")
 
 
 def test_runtime_dependencies_and_ci_are_pinned():
@@ -1036,7 +1040,9 @@ def test_runtime_dependencies_and_ci_are_pinned():
     assert_true("# v6.0.3" in workflow, "checkout pin annotation must identify the exact release")
     assert_true("# v6.2.0" in workflow, "setup-python pin annotation must identify the exact release")
     makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
-    assert_true("ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))" in makefile, "Makefile must resolve the repository root")
+    makefile_lines = set(makefile.splitlines())
+    assert_true("override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))" in makefile_lines, "Makefile must protect the repository root")
+    assert_true("PYTHON ?= python3" in makefile_lines, "Makefile must preserve the Python command override")
     assert_true('find "$(ROOT)"' in makefile, "Makefile cleanup must stay inside the repository")
     assert_true('"$(ROOT)/scripts/check_weatherbot_contracts.py"' in makefile, "Makefile must use the rooted contract path")
     assert_true('$(MAKE) -f "$(ROOT)/Makefile" clean' in makefile, "final cleanup must use the repository Makefile")


### PR DESCRIPTION
## Summary

Weatherbot verification and final cleanup can no longer be redirected away from the reviewed checkout through a command-line `ROOT` assignment. Absolute-Makefile portability and the configurable Python command remain intact.

## Baseline

The Make entry points accepted a command-line `ROOT` override, allowing verification and final cleanup to operate outside the reviewed checkout.

## Improvements

- protect the repository root used by verification and final cleanup
- preserve absolute-Makefile execution from external directories
- retain the intentionally configurable Python command

## Validation

- local, external-directory, and hostile-root pinned full gates
- 46 dependency-free contracts and 27 runtime tests per gate
- nine focused mutations
- dependency integrity, YAML, artifact, whitespace, and credential audits
- hosted verification succeeded on Python 3.10, 3.12, and 3.14 at the recorded head

## Risk

The change intentionally rejects command-line repository-root reassignment. Absolute-Makefile portability and Python command overrides remain supported.

## Follow-Ups

None required for this remediation.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
