### PR TITLE
docs: add weatherbot provider setup guide

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2026-06-14
+
+- Added a secret-safe provider setup guide covering all five required
+  credentials, the shared HTTPS Messenger webhook, optional settings, setup
+  order, and redacted verification evidence.
+
 ## 2026-06-13
 
 - Capped each signed Messenger webhook at 20 valid Wit action messages while

--- a/PROVIDER_SETUP.md
+++ b/PROVIDER_SETUP.md
@@ -1,0 +1,83 @@
+# Weatherbot Provider And Webhook Setup
+
+## Required Credentials
+
+Create and inject each value through the deployment platform's secret manager or
+environment configuration. Do not put values in this repository, command
+examples, screenshots, logs, issue text, or pull-request descriptions.
+
+| Variable | Owner | Purpose |
+| --- | --- | --- |
+| `WIT_TOKEN` | Wit.ai app | Authorizes intent and action requests. |
+| `FB_PAGE_TOKEN` | Meta Messenger page | Authorizes replies through the Messenger Send API. |
+| `FB_VERIFY_TOKEN` | Operator-chosen secret | Must match the token Meta sends during webhook verification. |
+| `FB_APP_SECRET` | Meta app | Verifies the `X-Hub-Signature-256` HMAC on Messenger POST bodies. |
+| `OPEN_WEATHER_TOKEN` | OpenWeather account | Authorizes current-weather lookups. |
+
+Keep the Messenger verify token, app secret, and page token distinct. Rotate a
+credential at its provider and deployment secret store together, then repeat the
+redacted verification steps below.
+
+## Callback Endpoint
+
+Deploy the Bottle process behind a public HTTPS origin and configure this exact
+callback URL in the Meta app:
+
+```text
+https://<public-host>/webhook
+```
+
+Both Messenger operations use `/webhook`:
+
+- `GET /webhook` handles subscription verification. Meta supplies
+  `hub.verify_token` and `hub.challenge`; Weatherbot returns the challenge as
+  plain text only when the configured verify token matches.
+- `POST /webhook` handles events. It requires `Content-Type: application/json`,
+  a valid `X-Hub-Signature-256` generated with `FB_APP_SECRET`, a body no larger
+  than 1 MiB, and a top-level Messenger object of `page`.
+
+Do not expose a direct HTTP-only callback. TLS termination may occur at the
+deployment platform, but the provider-facing callback must be HTTPS.
+
+## Optional Settings
+
+- `PORT` selects the Bottle listener port passed to `messenger.py`.
+- `REQUEST_TIMEOUT` sets a positive finite outbound timeout in seconds; invalid
+  values use `5.0`.
+- `WEATHERBOT_DEBUG=1` enables Bottle debug mode for local development only.
+- `WIT_URL` and `WIT_API_VERSION` override the legacy Wit endpoint and API
+  version for an intentional compatibility test.
+
+Do not enable debug mode in a public deployment or change provider origins
+without a separate security review.
+
+## Setup Order
+
+1. Create the Wit.ai app, Meta app/page, and OpenWeather account.
+2. Create or retrieve the five required credentials and inject them through the
+   deployment secret store without printing them.
+3. Deploy `python messenger.py $PORT` behind the public HTTPS origin.
+4. Register `https://<public-host>/webhook` in Meta, using the same
+   `FB_VERIFY_TOKEN` value in Meta and the deployment environment.
+5. Subscribe the page to message events only after GET verification succeeds.
+6. Run `make check` locally or in CI before any optional live provider test.
+
+## Redacted Verification Record
+
+Record the commit SHA, review date, reviewer, public callback hostname, provider
+names, and pass/fail status for these checks:
+
+- GET verification succeeds with the matching verify token and rejects a
+  mismatched token without echoing the challenge.
+- Unsigned, incorrectly signed, non-JSON, oversized, and non-page POST requests
+  are rejected before Wit actions.
+- A synthetic signed event passes the offline route suite without real user
+  identifiers, page IDs, conversation text, or provider credentials.
+- Optional live checks, when explicitly authorized, confirm one Wit intent, one
+  OpenWeather lookup, and one Messenger reply while retaining only redacted
+  pass/fail evidence.
+
+Never attach raw webhook payloads, conversation logs, provider responses,
+authorization headers, signatures, tokens, page IDs, or user identifiers.
+Unresolved verification or credential-boundary failures block deployment.
+

--- a/PROVIDER_SETUP.md
+++ b/PROVIDER_SETUP.md
@@ -80,4 +80,3 @@ names, and pass/fail status for these checks:
 Never attach raw webhook payloads, conversation logs, provider responses,
 authorization headers, signatures, tokens, page IDs, or user identifiers.
 Unresolved verification or credential-boundary failures block deployment.
-

--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ When the required SDK or runtime is unavailable, use static checks and source re
 
 ## Configuration and Secrets
 
+- See `PROVIDER_SETUP.md` for provider ownership, secret injection, the shared
+  HTTPS `/webhook` GET/POST contract, optional settings, setup order, and
+  redacted verification evidence.
 - `WIT_TOKEN` configures Wit.ai access.
 - `FB_PAGE_TOKEN` configures Facebook Messenger replies.
 - `FB_VERIFY_TOKEN` configures Messenger webhook verification.
@@ -133,6 +136,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   process-local retry suppression and per-message failure recovery.
 - See `docs/plans/2026-06-13-messenger-batch-processing-bound.md` for ordered,
   bounded Messenger batch handling and malformed-event isolation.
+- See `docs/plans/2026-06-14-provider-setup-guide.md` for provider credential,
+  endpoint, and redacted verification guidance.
 
 ## Contributing
 

--- a/VISION.md
+++ b/VISION.md
@@ -31,11 +31,12 @@ Priority:
 - Keep outbound request timeout configuration bounded and non-crashing
 - Keep Bottle debug mode disabled unless explicitly enabled locally
 - Avoid debug logging user messages, entities, or Wit response payloads
+- Keep provider credential ownership, HTTPS webhook wiring, and redacted
+  verification evidence explicit
 - Treat Python and API versions as legacy until documented
 
 Next priorities:
 
-- Add README setup notes for each token and webhook endpoint
 - Add user-facing fallback text for weather lookup failures
 - Document Python and dependency version constraints
 

--- a/docs/plans/2026-06-14-provider-setup-guide.md
+++ b/docs/plans/2026-06-14-provider-setup-guide.md
@@ -1,0 +1,39 @@
+# Weatherbot Provider Setup Guide
+
+## Status: Planned
+
+## Context
+
+The README lists Weatherbot environment variables but does not connect each
+secret to its provider, explain the shared Messenger webhook endpoint, or
+define a safe setup and verification sequence.
+
+## Requirements
+
+- Document ownership and purpose for Wit.ai, Messenger page, Messenger verify,
+  Messenger app-secret, and OpenWeather credentials.
+- Document `GET /webhook` verification and signed JSON `POST /webhook` delivery
+  on the same public HTTPS callback URL.
+- Explain optional timeout, debug, Wit host/version, and port settings.
+- Require secret-safe handling without checked-in values, inline examples,
+  private payloads, page IDs, or conversation logs.
+- Provide an ordered setup and redacted verification checklist that separates
+  local offline tests from optional live provider checks.
+- Link the guide from the README and roadmap and protect it with static
+  contracts and hostile mutations.
+
+## Verification Plan
+
+- focused provider-guide and completed-plan contracts
+- repository and external-directory `make check`
+- hostile token-purpose, endpoint, HTTPS, GET verification, POST signature,
+  media-type, privacy, optional-setting, verification, roadmap, suite, and
+  plan-status mutations
+- final artifact, credential, exact-diff, and hosted verification audits
+
+## Scope Boundary
+
+- Do not change runtime behavior, routes, tokens, provider origins,
+  dependencies, workflows, or deployment configuration.
+- Do not make live Wit.ai, Messenger, or OpenWeather calls.
+- Do not merge or close stacked pull requests without owner authorization.

--- a/docs/plans/2026-06-14-provider-setup-guide.md
+++ b/docs/plans/2026-06-14-provider-setup-guide.md
@@ -1,6 +1,6 @@
 # Weatherbot Provider Setup Guide
 
-## Status: Planned
+## Status: Completed
 
 ## Context
 
@@ -37,3 +37,22 @@ define a safe setup and verification sequence.
   dependencies, workflows, or deployment configuration.
 - Do not make live Wit.ai, Messenger, or OpenWeather calls.
 - Do not merge or close stacked pull requests without owner authorization.
+
+## Work Completed
+
+- Added provider ownership, credential-purpose, HTTPS callback, GET verification,
+  signed JSON POST, optional-setting, setup-order, and evidence guidance.
+- Linked the guide from repository documentation and made its requirements,
+  roadmap priority, suite registration, and completed plan mutation-sensitive.
+
+## Verification
+
+- Focused provider-guide and completed-plan contracts passed.
+- Repository and external-directory `make check` passed.
+- Thirteen hostile provider-guide mutations were rejected across credential
+  purposes, endpoints, HTTPS, GET verification, POST signatures, media types,
+  privacy, optional settings, evidence, roadmap, suite registration, and plan
+  status.
+- Dependency integrity, artifact, credential, and exact-diff audits passed.
+  Hosted verification is recorded against the exact pull-request head after
+  push.

--- a/scripts/check_weatherbot_contracts.py
+++ b/scripts/check_weatherbot_contracts.py
@@ -63,6 +63,9 @@ MESSENGER_BATCH_PLAN_PATH = (
 MAKE_ROOT_PROTECTION_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-14-make-root-override-protection.md"
 )
+PROVIDER_SETUP_PLAN_PATH = (
+    ROOT / "docs" / "plans" / "2026-06-14-provider-setup-guide.md"
+)
 
 
 class FakeBottle:
@@ -998,6 +1001,55 @@ def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(MESSENGER_REPLAY_PLAN_PATH, "weatherbot Messenger replay guard")
     assert_completed_plan(MESSENGER_BATCH_PLAN_PATH, "weatherbot Messenger batch processing bound")
     assert_completed_plan(MAKE_ROOT_PROTECTION_PLAN_PATH, "weatherbot Make root override protection")
+    assert_completed_plan(PROVIDER_SETUP_PLAN_PATH, "weatherbot provider setup guide")
+    checker_main = Path(__file__).read_text().rsplit("def main():", 1)[1]
+    assert_true(
+        "test_provider_setup_guide_is_auditable," in checker_main,
+        "provider setup guide contract must run in the main suite",
+    )
+
+
+def test_provider_setup_guide_is_auditable():
+    guide = " ".join((ROOT / "PROVIDER_SETUP.md").read_text(encoding="utf-8").split())
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    vision = (ROOT / "VISION.md").read_text(encoding="utf-8")
+    changes = (ROOT / "CHANGES.md").read_text(encoding="utf-8")
+
+    for contract in (
+        "`WIT_TOKEN` | Wit.ai app",
+        "`FB_PAGE_TOKEN` | Meta Messenger page",
+        "`FB_VERIFY_TOKEN` | Operator-chosen secret",
+        "`FB_APP_SECRET` | Meta app",
+        "`OPEN_WEATHER_TOKEN` | OpenWeather account",
+        "configure this exact callback URL in the Meta app",
+        "https://<public-host>/webhook",
+        "`GET /webhook` handles subscription verification",
+        "returns the challenge as plain text only when",
+        "`POST /webhook` handles events",
+        "`Content-Type: application/json`",
+        "valid `X-Hub-Signature-256` generated with `FB_APP_SECRET`",
+        "body no larger than 1 MiB",
+        "provider-facing callback must be HTTPS",
+        "`REQUEST_TIMEOUT` sets a positive finite outbound timeout",
+        "`WEATHERBOT_DEBUG=1` enables Bottle debug mode for local development only",
+        "Run `make check` locally or in CI before any optional live provider test",
+        "Never attach raw webhook payloads",
+        "Unresolved verification or credential-boundary failures block deployment",
+    ):
+        assert_true(contract in guide, "provider setup guide must include {0}".format(contract))
+    assert_true("See `PROVIDER_SETUP.md`" in readme, "README must link the provider setup guide")
+    assert_true(
+        "docs/plans/2026-06-14-provider-setup-guide.md" in readme,
+        "README must link the provider setup plan",
+    )
+    assert_true(
+        "Keep provider credential ownership, HTTPS webhook wiring" in vision,
+        "VISION must preserve provider setup guidance",
+    )
+    assert_true(
+        "secret-safe provider setup guide" in changes,
+        "CHANGES must record provider setup guidance",
+    )
 
 
 def test_runtime_dependencies_and_ci_are_pinned():
@@ -1155,6 +1207,7 @@ def main():
         test_get_forecast_handles_malformed_weather_results,
         test_get_forecast_handles_weather_lookup_exceptions,
         test_completed_plans_are_in_docs_plans,
+        test_provider_setup_guide_is_auditable,
         test_runtime_dependencies_and_ci_are_pinned,
     ]
     for test in tests:


### PR DESCRIPTION
## Summary

Weatherbot provider setup is now explicit and secret-safe. Operators can map every required credential to its owner, wire the shared Messenger callback correctly, and record redacted verification evidence without copying tokens, payloads, page IDs, or conversation data into the repository.

## Baseline

The README named environment variables but did not explain provider ownership, the shared `GET /webhook` and signed JSON `POST /webhook` contract, HTTPS requirements, setup order, or the boundary between offline and optional live verification.

## Improvements

- Documents all five required Wit.ai, Messenger, and OpenWeather credentials and keeps Messenger token roles distinct.
- Defines the exact public HTTPS callback, plain-text GET challenge behavior, POST media type/signature/body/object requirements, and optional runtime settings.
- Provides an ordered deployment sequence and redacted evidence checklist that requires offline `make check` before any explicitly authorized live provider test.

## Validation

- Repository and external-directory `make check` each passed 47 dependency-free contracts and 27 Bottle/WebTest runtime tests.
- Thirteen hostile provider-guide mutations were rejected.
- The exact runtime/test dependency environment passed `uv pip check` across 12 installed packages.
- Exact diff, generated-artifact, credential-pattern, and whitespace audits passed.

## Risk

Low. This is a documentation and static-contract change only; no routes, tokens, provider origins, dependencies, workflows, or deployment configuration changed. Live provider behavior remains intentionally untested without credentials and authorization.

## Follow-Ups

Operators should execute optional live checks only in an approved environment and retain redacted pass/fail evidence. This stacked PR must remain based on `lfg/weatherbot-make-root-protection-20260614` until its prerequisite PR is merged or rebased with owner authorization.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
