### PR TITLE
Reject failed Messenger provider replies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-15
+
+- Rejected unsuccessful Messenger provider responses before accepting reply
+  content, allowing failed message-ID claims to be retried.
+
 ## 2026-06-14
 
 - Added a secret-safe provider setup guide covering all five required

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   the valid webhook can be acknowledged.
 - Recent non-empty Messenger message IDs are claimed in a bounded process-local
   cache so retries do not repeat Wit actions; failed actions release claims.
+- Unsuccessful Messenger provider HTTP responses raise before reply content is
+  accepted, allowing the current webhook message-ID claim to be retried.
 - Signed Messenger batches process at most 20 valid user messages in payload
   order; malformed nested events and echoes do not hide later valid messages.
 - `OPEN_WEATHER_TOKEN` configures OpenWeather lookup.
@@ -138,6 +140,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   bounded Messenger batch handling and malformed-event isolation.
 - See `docs/plans/2026-06-14-provider-setup-guide.md` for provider credential,
   endpoint, and redacted verification guidance.
+- See `docs/plans/2026-06-15-messenger-reply-http-status.md` for Messenger
+  provider HTTP failure handling and replay-claim recovery.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,6 +48,8 @@ Recent non-empty Messenger message IDs are claimed before Wit actions in a
 bounded process-local cache. Duplicate deliveries are acknowledged without
 repeating actions, while failed actions release their claims for provider
 retries. Claims do not span workers or process restarts.
+Messenger provider HTTP errors propagate through the Wit action and release
+the current message-ID claim so a later webhook delivery can retry the reply.
 Each signed webhook processes at most 20 valid Messenger user messages in
 payload order. Malformed nested sender or message values are ignored without
 preventing later valid events from reaching Wit.

--- a/VISION.md
+++ b/VISION.md
@@ -21,6 +21,8 @@ Priority:
 - Reject blank Messenger message text before Wit action handling
 - Suppress retried Messenger message IDs before repeating Wit actions
 - Process Messenger message batches in order with a fixed per-webhook cap
+- Fail Messenger replies on provider HTTP errors so webhook retries remain
+  recoverable
 - Isolate expected Wit failures per Messenger event to avoid batch retry
   amplification after earlier replies
 - Make weather lookup and response flow easy to trace

--- a/docs/plans/2026-06-15-messenger-reply-http-status.md
+++ b/docs/plans/2026-06-15-messenger-reply-http-status.md
@@ -1,0 +1,39 @@
+# Fail Messenger Replies on Provider HTTP Errors
+
+## Status: In Progress
+
+## Context
+
+The Messenger reply client applies a timeout and bearer authentication, but it
+returns the provider response body without checking the HTTP status. A 4xx or
+5xx response is therefore treated as successful, so the enclosing Wit action
+does not raise and the webhook's message-ID claim remains consumed.
+
+## Requirements
+
+- Raise on unsuccessful Messenger provider responses before accepting reply
+  content.
+- Preserve timeout, header authentication, successful response behavior, and
+  the existing Wit action boundary.
+- Prove that a provider HTTP error propagates through the Wit action and releases
+  the webhook replay claim for a later delivery.
+- Add fail-closed source, runtime-test, documentation, and plan contracts.
+
+## Verification Plan
+
+- focused Messenger reply and replay contracts
+- hostile removal, ordering, fake-response, runtime-test, documentation, and
+  plan-status mutations
+- repository and external-directory `make check` with bounded execution
+- dependency integrity, exact diff, artifact, and credential-pattern audits
+
+## Scope Boundaries
+
+- Do not add automatic provider retries or change provider endpoints or tokens.
+- Do not merge or close stacked pull requests without owner authorization.
+
+## Work Pending
+
+- Add the provider HTTP status boundary and mutation-sensitive regressions.
+- Update operator and security documentation.
+- Run the bounded verification and record the actual evidence.

--- a/docs/plans/2026-06-15-messenger-reply-http-status.md
+++ b/docs/plans/2026-06-15-messenger-reply-http-status.md
@@ -1,6 +1,6 @@
 # Fail Messenger Replies on Provider HTTP Errors
 
-## Status: In Progress
+## Status: Completed
 
 ## Context
 
@@ -32,8 +32,25 @@ does not raise and the webhook's message-ID claim remains consumed.
 - Do not add automatic provider retries or change provider endpoints or tokens.
 - Do not merge or close stacked pull requests without owner authorization.
 
-## Work Pending
+## Work Completed
 
-- Add the provider HTTP status boundary and mutation-sensitive regressions.
-- Update operator and security documentation.
-- Run the bounded verification and record the actual evidence.
+- Added an explicit provider HTTP status check before Messenger reply content is
+  accepted.
+- Added dependency-free and Bottle/WebTest regressions proving provider HTTP
+  errors propagate through Wit actions and release replay claims.
+- Added fail-closed source-order, runtime-test, documentation, and completed-plan
+  contracts, plus operator and security documentation.
+
+## Verification
+
+- Focused HTTP-status contracts passed 3 tests, and the dependency-free suite
+  passed 49 tests.
+- Repository and external-directory `make check` passed under pinned Python
+  3.12, with 49 contracts and 28 runtime tests in each run.
+- Five targeted behavior and documentation mutations were rejected before plan
+  completion; the completed-plan mutation was then rejected separately.
+- `uv pip check` passed for all 13 installed packages. Direct `pip-audit` runs
+  found no known vulnerabilities in runtime or test requirements; the private
+  WebOb build was explicitly reported as unavailable on PyPI and unauditable.
+- A broader disposable-environment audit found vulnerabilities only in that
+  environment's `pip 24.3.1`, which is tooling and is not a repository pin.

--- a/messenger.py
+++ b/messenger.py
@@ -267,6 +267,7 @@ def fb_message(sender_id, text):
         json=data,
         headers={'Authorization': 'Bearer {0}'.format(FB_PAGE_TOKEN or '')},
         timeout=REQUEST_TIMEOUT)
+    resp.raise_for_status()
     return resp.content
 
 

--- a/scripts/check_weatherbot_contracts.py
+++ b/scripts/check_weatherbot_contracts.py
@@ -66,6 +66,9 @@ MAKE_ROOT_PROTECTION_PLAN_PATH = (
 PROVIDER_SETUP_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-14-provider-setup-guide.md"
 )
+MESSENGER_REPLY_HTTP_STATUS_PLAN_PATH = (
+    ROOT / "docs" / "plans" / "2026-06-15-messenger-reply-http-status.md"
+)
 
 
 class FakeBottle:
@@ -96,9 +99,10 @@ class MutableResponse:
 
 
 class FakeHTTPResponse:
-    def __init__(self, content, payload=None):
+    def __init__(self, content, payload=None, error=None):
         self.content = content
         self._payload = payload or {}
+        self._error = error
         self.status_code = 200
         self.reason = "OK"
 
@@ -106,17 +110,20 @@ class FakeHTTPResponse:
         return self._payload
 
     def raise_for_status(self):
-        return None
+        if self._error is not None:
+            raise self._error
 
 
 class FakeRequests(types.SimpleNamespace):
     def __init__(self):
         super(FakeRequests, self).__init__()
         self.calls = []
+        self.response_error = None
 
     def post(self, url, **kwargs):
         self.calls.append(("post", url, kwargs))
-        return FakeHTTPResponse(b'{"recipient_id": "user-1"}')
+        return FakeHTTPResponse(
+            b'{"recipient_id": "user-1"}', error=self.response_error)
 
     def get(self, url, params=None, **kwargs):
         kwargs["params"] = params
@@ -756,6 +763,57 @@ def test_fb_message_uses_header_auth_and_timeout():
     )
 
 
+def test_messenger_post_releases_claim_after_provider_http_error():
+    messenger, request, _response, requests, _calls = load_messenger()
+    request.json = messenger_payload("mid-provider-http-error")
+    requests.response_error = RuntimeError("provider rejected reply")
+    messenger.client = types.SimpleNamespace(
+        run_actions=lambda session_id, message: messenger.fb_message(session_id, message)
+    )
+
+    try:
+        messenger.messenger_post()
+        raise AssertionError("Messenger provider HTTP errors must propagate")
+    except RuntimeError as exc:
+        assert_equal(str(exc), "provider rejected reply", "provider HTTP error")
+
+    requests.response_error = None
+    assert_equal(messenger.messenger_post(), "ok", "retry after provider HTTP error")
+    post_calls = [call for call in requests.calls if call[0] == "post"]
+    assert_equal(len(post_calls), 2, "provider HTTP error must release replay claim")
+
+
+def test_fb_message_http_status_source_contracts():
+    source = (ROOT / "messenger.py").read_text(encoding="utf-8")
+    runtime_tests = (ROOT / "test_messenger.py").read_text(encoding="utf-8")
+    reply_start = source.index("def fb_message")
+    reply_end = source.index("def get_weather", reply_start)
+    reply_source = source[reply_start:reply_end]
+    post_position = reply_source.index("requests.post(")
+    status_position = reply_source.index("resp.raise_for_status()")
+    return_position = reply_source.index("return resp.content")
+    assert_true(
+        post_position < status_position < return_position,
+        "Messenger reply must reject provider HTTP errors before returning content",
+    )
+    assert_true(
+        "test_facebook_response_raises_for_http_error" in runtime_tests,
+        "Bottle/WebTest suite must cover Messenger provider HTTP errors",
+    )
+
+    docs = {
+        "README.md": "Unsuccessful Messenger provider HTTP responses raise",
+        "SECURITY.md": "Messenger provider HTTP errors propagate",
+        "VISION.md": "Fail Messenger replies on provider HTTP errors",
+        "CHANGES.md": "Rejected unsuccessful Messenger provider responses",
+    }
+    for relative_path, phrase in docs.items():
+        assert_true(
+            phrase in (ROOT / relative_path).read_text(encoding="utf-8"),
+            "{0} must document Messenger provider HTTP failures".format(relative_path),
+        )
+
+
 def test_weather_lookup_uses_https_params_and_timeout():
     messenger, _request, _response, requests, _calls = load_messenger()
 
@@ -1002,6 +1060,7 @@ def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(MESSENGER_BATCH_PLAN_PATH, "weatherbot Messenger batch processing bound")
     assert_completed_plan(MAKE_ROOT_PROTECTION_PLAN_PATH, "weatherbot Make root override protection")
     assert_completed_plan(PROVIDER_SETUP_PLAN_PATH, "weatherbot provider setup guide")
+    assert_completed_plan(MESSENGER_REPLY_HTTP_STATUS_PLAN_PATH, "weatherbot Messenger reply HTTP status")
     checker_main = Path(__file__).read_text().rsplit("def main():", 1)[1]
     assert_true(
         "test_provider_setup_guide_is_auditable," in checker_main,
@@ -1193,6 +1252,8 @@ def main():
         test_messenger_post_ignores_invalid_sender_ids,
         test_messenger_post_trims_sender_id,
         test_fb_message_uses_header_auth_and_timeout,
+        test_messenger_post_releases_claim_after_provider_http_error,
+        test_fb_message_http_status_source_contracts,
         test_weather_lookup_uses_https_params_and_timeout,
         test_weather_lookup_handles_malformed_results,
         test_request_timeout_accepts_positive_float_env,

--- a/test_messenger.py
+++ b/test_messenger.py
@@ -441,6 +441,9 @@ class TestMessenger(unittest.TestCase):
             def __init__(self, user_id):
                 self.content = json.dumps({'recipient_id': user_id})
 
+            def raise_for_status(self):
+                return None
+
         def fake_post(url, **kwargs):
             calls.append((url, kwargs))
             return FakeResponse(self.user_id)
@@ -457,6 +460,22 @@ class TestMessenger(unittest.TestCase):
         self.assertEqual(calls[0][1]['headers']['Authorization'],
                          'Bearer ' + messenger.FB_PAGE_TOKEN)
         self.assertEqual(calls[0][1]['timeout'], messenger.REQUEST_TIMEOUT)
+
+    def test_facebook_response_raises_for_http_error(self):
+        original_post = messenger.requests.post
+
+        class FailedResponse(object):
+            content = b'provider error'
+
+            def raise_for_status(self):
+                raise RuntimeError('provider rejected reply')
+
+        messenger.requests.post = lambda _url, **_kwargs: FailedResponse()
+        try:
+            with self.assertRaisesRegex(RuntimeError, 'provider rejected reply'):
+                messenger.fb_message(self.user_id, 'hello this is a test')
+        finally:
+            messenger.requests.post = original_post
 
     def test_weather(self):
         original_get = messenger.requests.get


### PR DESCRIPTION
## Summary

- reject Messenger provider 4xx/5xx responses before accepting reply content
- propagate the failure through the synchronous Wit action so the existing webhook handler releases the message-ID claim
- add dependency-free, Bottle/WebTest, source-order, documentation, and completed-plan contracts

## Baseline

- Messenger provider error responses could reach reply-content handling without an explicit 4xx/5xx rejection boundary.
- Recovery relies on the existing webhook exception path releasing the message-ID claim so retries remain possible.

## Improvements

- Validate Messenger provider HTTP status before accepting reply content.
- Propagate provider failures through the synchronous Wit action into the established webhook recovery path.
- Cover the boundary with dependency-free, integration, source-order, documentation, and completed-plan contracts.

## Validation

- focused Messenger HTTP-status contracts: 3 passed
- dependency-free contracts: 49 passed
- repository and external-directory `make check`: 49 contracts and 28 runtime tests each under pinned Python 3.12
- six targeted mutations rejected, including removed/unreachable status checks and incomplete plan evidence
- `uv pip check`: 13 installed packages compatible
- direct runtime/test requirement audits: no known vulnerabilities; private WebOb build explicitly unauditable
- exact diff, generated-artifact, conflict-marker, and high-confidence credential audits passed

## Risk

- Validation does not exercise live Messenger, Wit.ai, OpenWeather, or production webhook retry behavior.
- The private WebOb build cannot be evaluated by the package vulnerability audit.

## Follow-Ups

- Review and merge the stacked base PR before this change to preserve branch ordering.
- Observe live provider failures and webhook retry behavior after deployment.

## Stack

Base: #15 (`lfg/weatherbot-provider-setup-guide-20260614`)
