### PR TITLE
fix: add weather failure user message

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 2026-06-16
+
+- Replaced stale Wit response text with a stable retry-later message when a
+  known-location OpenWeather lookup fails.
+- Preserved normal Wit replies for successful forecasts, missing-location
+  prompts, absent context, and malformed non-boolean failure state.
+
 ## 2026-06-15
 
 - Rejected unsuccessful Messenger provider responses before accepting reply

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - Expected Wit transport and response failures are isolated to the affected
   Messenger event so later messages in an authenticated batch still run and
   the valid webhook can be acknowledged.
+- Known-location weather lookup failures send a stable retry-later message
+  instead of forwarding stale Wit forecast text or provider details.
 - Recent non-empty Messenger message IDs are claimed in a bounded process-local
   cache so retries do not repeat Wit actions; failed actions release claims.
 - Unsuccessful Messenger provider HTTP responses raise before reply content is
@@ -142,6 +144,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   endpoint, and redacted verification guidance.
 - See `docs/plans/2026-06-15-messenger-reply-http-status.md` for Messenger
   provider HTTP failure handling and replay-claim recovery.
+- See `docs/plans/2026-06-16-weather-failure-user-message.md` for the stable
+  user-facing reply when a known-location weather lookup is unavailable.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,6 +50,9 @@ repeating actions, while failed actions release their claims for provider
 retries. Claims do not span workers or process restarts.
 Messenger provider HTTP errors propagate through the Wit action and release
 the current message-ID claim so a later webhook delivery can retry the reply.
+OpenWeather failures for a known location produce a stable user-facing
+retry-later message. Provider exception text and stale Wit forecast copy are
+not forwarded to the Messenger user.
 Each signed webhook processes at most 20 valid Messenger user messages in
 payload order. Malformed nested sender or message values are ignored without
 preventing later valid events from reaching Wit.

--- a/VISION.md
+++ b/VISION.md
@@ -30,6 +30,7 @@ Priority:
 - Normalize flat and nested Wit location values before weather lookup
 - Treat malformed OpenWeather results as missing forecasts
 - Treat OpenWeather lookup exceptions as missing forecasts
+- Send stable retry-later text when a known-location forecast is unavailable
 - Keep outbound request timeout configuration bounded and non-crashing
 - Keep Bottle debug mode disabled unless explicitly enabled locally
 - Avoid debug logging user messages, entities, or Wit response payloads
@@ -39,7 +40,6 @@ Priority:
 
 Next priorities:
 
-- Add user-facing fallback text for weather lookup failures
 - Document Python and dependency version constraints
 
 Contribution rules:

--- a/docs/plans/2026-06-16-weather-failure-user-message.md
+++ b/docs/plans/2026-06-16-weather-failure-user-message.md
@@ -1,0 +1,50 @@
+# Weather Failure User Message
+
+## Status: Planned
+
+## Context
+
+`get_forecast` already distinguishes a missing location from a known location
+whose OpenWeather lookup failed by setting `missingLocation` or
+`missingForecast`. The `send` action ignores that state and forwards Wit.ai's
+response text unchanged. A provider failure can therefore return stale or
+misleading forecast copy instead of a stable repository-controlled fallback.
+
+## Requirements
+
+- Define a concise user-facing message for known-location weather lookup
+  failures.
+- Use that fallback only when the action request context explicitly carries
+  `missingForecast` as the boolean `True`; malformed truthy values must not
+  broaden the override.
+- Preserve normal Wit response text for successful forecasts, missing-location
+  prompts, and requests with absent or malformed context.
+- Keep Messenger provider HTTP errors visible to the webhook retry path.
+- Add executable and static mutation-sensitive coverage for the override and
+  its non-overriding branches.
+- Update the roadmap, maintenance documentation, changelog, and completed plan
+  evidence without changing provider credentials or live API behavior.
+
+## Key Decision
+
+Apply the fallback in `send`, immediately before `fb_message`, because that is
+the final repository-owned boundary between Wit action state and Messenger
+reply text. Do not overload `forecast` with an error string or require external
+Wit configuration changes; successful weather context remains structured and
+the missing-location response remains owned by the existing Wit conversation.
+
+## Verification Plan
+
+- Run focused action tests for failed, successful, missing-location, absent,
+  and malformed context.
+- Run isolated hostile mutations that remove the override, broaden it to
+  missing-location state, or allow Wit text to replace the fallback.
+- Run bounded repository and external-directory `make check` gates.
+- Audit the exact diff, generated artifacts, whitespace, file modes, and
+  changed lines for credential material.
+
+## Scope Boundaries
+
+- Do not call live Messenger, Wit.ai, or OpenWeather services.
+- Do not add retry, localization, or conversational-state infrastructure.
+- Do not merge or close stacked pull requests without explicit authorization.

--- a/docs/plans/2026-06-16-weather-failure-user-message.md
+++ b/docs/plans/2026-06-16-weather-failure-user-message.md
@@ -1,6 +1,6 @@
 # Weather Failure User Message
 
-## Status: Planned
+## Status: Completed
 
 ## Context
 
@@ -48,3 +48,23 @@ the missing-location response remains owned by the existing Wit conversation.
 - Do not call live Messenger, Wit.ai, or OpenWeather services.
 - Do not add retry, localization, or conversational-state infrastructure.
 - Do not merge or close stacked pull requests without explicit authorization.
+
+## Work Completed
+
+- Added a stable retry-later message for exact boolean `missingForecast`
+  context at the final Messenger send boundary.
+- Preserved Wit response text for successful forecasts, missing-location state,
+  absent context, and malformed non-boolean failure values.
+- Added executable and dependency-free regressions plus documentation,
+  security, roadmap, and changelog contracts.
+
+## Verification Results
+
+- The focused missing-forecast and preservation tests passed.
+- The complete Bottle/WebTest suite passed all 30 tests.
+- Five isolated production mutations were rejected: disabled override, truthy
+  state broadening, removed fallback assignment, unsafe context indexing, and
+  restored dependency on Wit response text.
+- Repository and external-directory `make check` gates each passed 50
+  dependency-free contracts and all 30 Bottle/WebTest tests.
+- No live Messenger, Wit.ai, or OpenWeather request was made.

--- a/messenger.py
+++ b/messenger.py
@@ -39,6 +39,9 @@ FB_APP_SECRET = os.environ.get('FB_APP_SECRET')
 OPEN_WEATHER_TOKEN = os.environ.get('OPEN_WEATHER_TOKEN')
 FB_MESSAGES_URL = 'https://graph.facebook.com/me/messages'
 OPEN_WEATHER_URL = 'https://api.openweathermap.org/data/2.5/weather'
+WEATHER_UNAVAILABLE_MESSAGE = (
+    "I couldn't get the weather right now. Please try again."
+)
 
 
 def positive_float_from_env(name, default):
@@ -317,7 +320,11 @@ def send(request, response):
     """
     # We use the fb_id as equal to session_id
     fb_id = request['session_id']
-    text = response['text']
+    context = request.get('context')
+    if isinstance(context, dict) and context.get('missingForecast') is True:
+        text = WEATHER_UNAVAILABLE_MESSAGE
+    else:
+        text = response['text']
     # send message
     fb_message(fb_id, text)
 

--- a/scripts/check_weatherbot_contracts.py
+++ b/scripts/check_weatherbot_contracts.py
@@ -69,6 +69,9 @@ PROVIDER_SETUP_PLAN_PATH = (
 MESSENGER_REPLY_HTTP_STATUS_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-15-messenger-reply-http-status.md"
 )
+WEATHER_FAILURE_MESSAGE_PLAN_PATH = (
+    ROOT / "docs" / "plans" / "2026-06-16-weather-failure-user-message.md"
+)
 
 
 class FakeBottle:
@@ -850,6 +853,72 @@ def test_weather_lookup_handles_malformed_results():
         assert_equal(messenger.get_weather("Yountville"), None, "malformed weather response")
 
 
+def test_send_uses_weather_failure_user_message():
+    messenger, _request, _response, _requests, _calls = load_messenger()
+    replies = []
+    messenger.fb_message = lambda user_id, text: replies.append((user_id, text))
+
+    messenger.send(
+        {"session_id": "user-1", "context": {"missingForecast": True}},
+        {},
+    )
+    assert_equal(
+        replies,
+        [("user-1", "I couldn't get the weather right now. Please try again.")],
+        "missing forecast reply",
+    )
+
+    for context in ({}, {"missingLocation": True}, {"missingForecast": False}, {"missingForecast": 1}, None, []):
+        replies[:] = []
+        messenger.send(
+            {"session_id": "user-1", "context": context},
+            {"text": "Which location should I check?"},
+        )
+        assert_equal(
+            replies,
+            [("user-1", "Which location should I check?")],
+            "non-failure reply for context {0!r}".format(context),
+        )
+
+    replies[:] = []
+    messenger.send(
+        {"session_id": "user-1"},
+        {"text": "Which location should I check?"},
+    )
+    assert_equal(
+        replies,
+        [("user-1", "Which location should I check?")],
+        "missing context reply",
+    )
+
+    source = (ROOT / "messenger.py").read_text(encoding="utf-8")
+    runtime_tests = (ROOT / "test_messenger.py").read_text(encoding="utf-8")
+    assert_true(
+        "context.get('missingForecast') is True" in source,
+        "weather fallback must require exact boolean missingForecast state",
+    )
+    assert_true(
+        "test_send_uses_stable_text_for_missing_forecast" in runtime_tests,
+        "Bottle/WebTest suite must cover the missing-forecast override",
+    )
+    assert_true(
+        "test_send_preserves_wit_text_without_exact_missing_forecast" in runtime_tests,
+        "Bottle/WebTest suite must cover non-overriding contexts",
+    )
+
+    docs = {
+        "README.md": "Known-location weather lookup failures send a stable retry-later message",
+        "SECURITY.md": "Provider exception text and stale Wit forecast copy are",
+        "VISION.md": "Send stable retry-later text when a known-location forecast is unavailable",
+        "CHANGES.md": "Replaced stale Wit response text with a stable retry-later message",
+    }
+    for relative_path, phrase in docs.items():
+        assert_true(
+            phrase in (ROOT / relative_path).read_text(encoding="utf-8"),
+            "{0} must document the weather failure user message".format(relative_path),
+        )
+
+
 def test_request_timeout_accepts_positive_float_env():
     messenger_timeout, wit_timeout = load_timeout_values("2.5")
 
@@ -1061,6 +1130,7 @@ def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(MAKE_ROOT_PROTECTION_PLAN_PATH, "weatherbot Make root override protection")
     assert_completed_plan(PROVIDER_SETUP_PLAN_PATH, "weatherbot provider setup guide")
     assert_completed_plan(MESSENGER_REPLY_HTTP_STATUS_PLAN_PATH, "weatherbot Messenger reply HTTP status")
+    assert_completed_plan(WEATHER_FAILURE_MESSAGE_PLAN_PATH, "weatherbot weather failure user message")
     checker_main = Path(__file__).read_text().rsplit("def main():", 1)[1]
     assert_true(
         "test_provider_setup_guide_is_auditable," in checker_main,
@@ -1256,6 +1326,7 @@ def main():
         test_fb_message_http_status_source_contracts,
         test_weather_lookup_uses_https_params_and_timeout,
         test_weather_lookup_handles_malformed_results,
+        test_send_uses_weather_failure_user_message,
         test_request_timeout_accepts_positive_float_env,
         test_request_timeout_defaults_for_invalid_env,
         test_bottle_debug_is_disabled_by_default,

--- a/test_messenger.py
+++ b/test_messenger.py
@@ -477,6 +477,41 @@ class TestMessenger(unittest.TestCase):
         finally:
             messenger.requests.post = original_post
 
+    def test_send_uses_stable_text_for_missing_forecast(self):
+        with mock.patch.object(messenger, 'fb_message') as fb_message:
+            messenger.send(
+                {'session_id': self.user_id,
+                 'context': {'missingForecast': True}},
+                {})
+
+        fb_message.assert_called_once_with(
+            self.user_id,
+            "I couldn't get the weather right now. Please try again.")
+
+    def test_send_preserves_wit_text_without_exact_missing_forecast(self):
+        contexts = [
+            {},
+            {'missingLocation': True},
+            {'missingForecast': False},
+            {'missingForecast': 1},
+            None,
+            [],
+        ]
+
+        with mock.patch.object(messenger, 'fb_message') as fb_message:
+            for context in contexts:
+                request = {'session_id': self.user_id, 'context': context}
+                messenger.send(request, {'text': 'Which location should I check?'})
+                fb_message.assert_called_once_with(
+                    self.user_id, 'Which location should I check?')
+                fb_message.reset_mock()
+
+            messenger.send(
+                {'session_id': self.user_id},
+                {'text': 'Which location should I check?'})
+            fb_message.assert_called_once_with(
+                self.user_id, 'Which location should I check?')
+
     def test_weather(self):
         original_get = messenger.requests.get
 


### PR DESCRIPTION
## Summary

When OpenWeather fails for a known location, users now receive a stable retry-later reply instead of stale Wit forecast text. The fallback is fully repository-controlled and no longer depends on Wit returning a text field.

## Baseline

`get_forecast` already marked known-location failures with `missingForecast`, but `send` ignored that state and forwarded `response['text']` unchanged. Missing-location prompts and successful forecast replies already had the desired behavior.

## Improvements

- Override reply text only when `missingForecast` is exactly boolean `True`.
- Preserve normal Wit text for successful, missing-location, absent-context, and malformed-context paths.
- Keep Messenger provider HTTP failures propagating so webhook replay claims remain recoverable.
- Bind behavior, documentation, security posture, roadmap state, and the completed plan with executable and dependency-free contracts.

## Validation

- Repository and external-directory `make check`: 50 dependency-free contracts and 30 Bottle/WebTest tests passed in each context.
- Five isolated production mutations were rejected, including restored response-text dependency and truthy-state broadening.
- Exact eight-file diff, artifact, whitespace, mode, conflict-marker, and credential-signature audits passed.
- Browser testing is not applicable because this change has no rendered browser route; provider calls are exercised through fakes.

## Risk

The behavior changes only the final Messenger text for exact `missingForecast: True` action state. No live Messenger, Wit.ai, or OpenWeather request was made, so deployment credentials and provider-specific conversation configuration remain environment-dependent.

## Follow-Ups

- Document Python and dependency version constraints, the next remaining roadmap priority.
- Preserve base-first ordering because this PR is stacked on PR #16.

## Post-Deploy Monitoring & Validation

- For the first 24 hours after deployment, the service owner should search application logs for `Wit request failed`, OpenWeather request failures, Messenger provider HTTP errors, and unexpected `KeyError` exceptions in the `send` action.
- Healthy signal: known-location weather failures produce the stable retry-later reply while successful forecasts and missing-location prompts retain their existing text.
- Failure signal: increased webhook retries, missing replies, fallback text on successful forecasts, or response-text exceptions. Roll back this commit if any of those signals appear and reproduce with the provider-fake action tests before redeploying.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
