### PR TITLE
docs: define weatherbot version support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@
 
 - Language mix noted in the README: Python (3).
 - Prefer dependency-free tests or stdlib checks when legacy packages are unavailable.
+- Verified support covers Python 3.10, 3.12, and 3.14 with Bottle 0.13.4, Requests 2.34.2, and WebTest 3.0.7 pinned exactly.
 
 ## Testing guidance
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## 2026-06-16
 
+- Verified support covers Python 3.10, 3.12, and 3.14 with Bottle 0.13.4, Requests 2.34.2, and WebTest 3.0.7 pinned exactly.
 - Replaced stale Wit response text with a stable retry-later message when a
   known-location OpenWeather lookup fails.
 - Preserved normal Wit replies for successful forecasts, missing-location

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Additional scan context:
 
 - Git
 - Python 3.10 or newer; deployment tracks the Python 3.14 line
+- Verified support covers Python 3.10, 3.12, and 3.14 with Bottle 0.13.4, Requests 2.34.2, and WebTest 3.0.7 pinned exactly.
 
 ### Setup
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -72,6 +72,8 @@ tokens, sender IDs, message text, request URLs, or provider response bodies.
 
 Dependency updates should come from trusted package managers and should keep lockfiles in sync when lockfiles exist. Do not commit credentials, private keys, tokens, generated secrets, or machine-local configuration. If a vulnerability depends on a compromised package, typosquatting risk, insecure transitive dependency, or unsafe build step, include the package name, affected version, and the path through which it is used.
 
+Verified support covers Python 3.10, 3.12, and 3.14 with Bottle 0.13.4, Requests 2.34.2, and WebTest 3.0.7 pinned exactly.
+
 ## Safe Research Guidelines
 
 Good-faith research is welcome when it stays within these boundaries:

--- a/VISION.md
+++ b/VISION.md
@@ -36,11 +36,8 @@ Priority:
 - Avoid debug logging user messages, entities, or Wit response payloads
 - Keep provider credential ownership, HTTPS webhook wiring, and redacted
   verification evidence explicit
-- Treat Python and API versions as legacy until documented
-
-Next priorities:
-
-- Document Python and dependency version constraints
+- Verified support covers Python 3.10, 3.12, and 3.14 with Bottle 0.13.4, Requests 2.34.2, and WebTest 3.0.7 pinned exactly.
+- Treat provider API behavior as credential-bound until live version contracts are reviewed
 
 Contribution rules:
 

--- a/docs/plans/2026-06-16-python-dependency-version-contract.md
+++ b/docs/plans/2026-06-16-python-dependency-version-contract.md
@@ -1,0 +1,53 @@
+# Document Python and Dependency Versions
+
+Status: Planned
+
+## Context
+
+Weatherbot already pins Bottle, Requests, and WebTest exactly and verifies the
+repository on Python 3.10, 3.12, and 3.14. The roadmap still describes Python
+and API versions as legacy until documented, so maintainers do not have one
+stable statement that connects the manifests to the hosted compatibility
+matrix.
+
+## Goals
+
+- Document the exact runtime and test dependency pins.
+- Document Python 3.10, 3.12, and 3.14 as the verified compatibility matrix.
+- Keep the matrix, manifest contents, and guidance mutation-sensitive.
+- Remove the completed documentation item and legacy ambiguity from the vision.
+
+## Non-Goals
+
+- Do not change dependency versions or add a package manager.
+- Do not claim compatibility with Python versions outside the hosted matrix.
+- Do not claim a current Wit.ai, Messenger, or OpenWeather API-version contract
+  without credential-backed integration verification.
+- Do not change runtime behavior, provider requests, or deployment settings.
+
+## Implementation
+
+1. Add one canonical supported-version statement to README, security,
+   contributor, vision, and changelog guidance.
+2. Update the vision to distinguish verified Python/dependency versions from
+   provider API versions that still require live review.
+3. Extend `scripts/check_weatherbot_contracts.py` to preserve the exact
+   manifests, hosted matrix, guidance, and completed plan.
+
+## Validation
+
+- Run the dependency-free contract suite and Bottle/WebTest route suite.
+- Run repository and external-directory `make check` with the pinned packages.
+- Reject mutations that change a runtime pin, test pin, Python matrix,
+  guidance, completed status, or verification evidence.
+- Audit the exact diff, Python syntax, artifacts, credentials, conflict markers,
+  modes, and whitespace before commit.
+
+## Risks
+
+- Exact pins require deliberate updates when upstream security or compatibility
+  releases are adopted.
+- Provider API behavior remains environment-dependent and is not converted into
+  an offline version guarantee by this documentation.
+- PR #18 will be stacked on open PR #17 and requires base-first ordering;
+  neither pull request may be merged or closed without explicit authorization.

--- a/docs/plans/2026-06-16-python-dependency-version-contract.md
+++ b/docs/plans/2026-06-16-python-dependency-version-contract.md
@@ -1,6 +1,6 @@
 # Document Python and Dependency Versions
 
-Status: Planned
+Status: Completed
 
 ## Context
 
@@ -51,3 +51,19 @@ matrix.
   an offline version guarantee by this documentation.
 - PR #18 will be stacked on open PR #17 and requires base-first ordering;
   neither pull request may be merged or closed without explicit authorization.
+
+## Verification Results
+
+Completed on 2026-06-16:
+
+- Bottle/WebTest route suite: a clean Python 3.12 environment installed Bottle
+  0.13.4, Requests 2.34.2, and WebTest 3.0.7, passed `pip check`, and ran all 30
+  route tests.
+- The dependency-free contract suite passed 51 checks, including the manifest,
+  Python matrix, guidance, and completed-plan contracts.
+- Repository and external-directory `make check` passed with the pinned
+  environment and the shell's unrelated `PYTHONPATH` unset.
+- Six hostile mutations were rejected across the runtime pin, test pin, Python
+  matrix, guidance, completed status, and verification evidence.
+- Exact diff, Python syntax, artifact, credential-pattern, conflict-marker,
+  mode, and whitespace audits passed before commit.

--- a/scripts/check_weatherbot_contracts.py
+++ b/scripts/check_weatherbot_contracts.py
@@ -72,6 +72,9 @@ MESSENGER_REPLY_HTTP_STATUS_PLAN_PATH = (
 WEATHER_FAILURE_MESSAGE_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-16-weather-failure-user-message.md"
 )
+VERSION_CONTRACT_PLAN_PATH = (
+    ROOT / "docs" / "plans" / "2026-06-16-python-dependency-version-contract.md"
+)
 
 
 class FakeBottle:
@@ -1131,10 +1134,15 @@ def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(PROVIDER_SETUP_PLAN_PATH, "weatherbot provider setup guide")
     assert_completed_plan(MESSENGER_REPLY_HTTP_STATUS_PLAN_PATH, "weatherbot Messenger reply HTTP status")
     assert_completed_plan(WEATHER_FAILURE_MESSAGE_PLAN_PATH, "weatherbot weather failure user message")
+    assert_completed_plan(VERSION_CONTRACT_PLAN_PATH, "weatherbot Python and dependency versions")
     checker_main = Path(__file__).read_text().rsplit("def main():", 1)[1]
     assert_true(
         "test_provider_setup_guide_is_auditable," in checker_main,
         "provider setup guide contract must run in the main suite",
+    )
+    assert_true(
+        "test_supported_version_guidance," in checker_main,
+        "supported version guidance contract must run in the main suite",
     )
 
 
@@ -1239,6 +1247,42 @@ def test_runtime_dependencies_and_ci_are_pinned():
     assert_true("test_facebook_verification_challenge_is_plain_text" in runtime_tests, "WebTest must cover challenge response type")
 
 
+def test_supported_version_guidance():
+    guidance = (
+        "Verified support covers Python 3.10, 3.12, and 3.14 with Bottle 0.13.4, "
+        "Requests 2.34.2, and WebTest 3.0.7 pinned exactly."
+    )
+    documents = {
+        name: (ROOT / name).read_text(encoding="utf-8")
+        for name in ("AGENTS.md", "README.md", "SECURITY.md", "VISION.md", "CHANGES.md")
+    }
+    for name, text in documents.items():
+        assert_true(guidance in text, name + " must document the supported version contract")
+    assert_true(
+        "Treat Python and API versions as legacy until documented" not in documents["VISION.md"],
+        "VISION must remove the stale undocumented-version classification",
+    )
+    assert_true(
+        "Document Python and dependency version constraints" not in documents["VISION.md"],
+        "VISION must remove the completed version-documentation priority",
+    )
+
+    plan = VERSION_CONTRACT_PLAN_PATH.read_text(encoding="utf-8")
+    assert_equal(plan.count("Status: Completed"), 1, "version plan completed status")
+    assert_equal(plan.count("Status:"), 1, "version plan status count")
+    verification = plan.split("## Verification Results", 1)[-1]
+    for evidence in (
+        "Bottle/WebTest route suite",
+        "external-directory `make check`",
+        "hostile mutations",
+    ):
+        assert_true(evidence in verification, "version plan verification: " + evidence)
+    assert_true(
+        not any(word in verification.lower() for word in ("pending", "todo", "tbd", "not run")),
+        "version plan verification must not contain placeholders",
+    )
+
+
 def test_messenger_post_rejects_oversized_declared_body():
     messenger, request, response, _requests, calls = load_messenger()
     request.content_length = messenger.MAX_MESSENGER_WEBHOOK_BYTES + 1
@@ -1341,6 +1385,7 @@ def main():
         test_completed_plans_are_in_docs_plans,
         test_provider_setup_guide_is_auditable,
         test_runtime_dependencies_and_ci_are_pinned,
+        test_supported_version_guidance,
     ]
     for test in tests:
         test()


### PR DESCRIPTION
## Summary

- document the exact Python compatibility matrix and dependency pins
- remove stale “legacy until documented” roadmap language
- enforce manifests, hosted matrix, guidance, and completed-plan evidence

## Baseline

Weatherbot already pinned Bottle 0.13.4, Requests 2.34.2, and WebTest 3.0.7 and tested Python 3.10, 3.12, and 3.14, but the vision still classified the versions as undocumented legacy behavior.

## Improvements

All operator and contributor guidance now states the verified matrix and exact pins consistently. A dedicated dependency-free contract preserves that statement, the manifest and workflow checks remain authoritative, and provider API behavior remains explicitly credential-bound rather than receiving an unsupported offline version claim.

## Validation

- clean Python 3.12 install of all exact runtime and test pins
- `python -m pip check`
- 51 dependency-free contracts
- 30 Bottle/WebTest route tests
- repository and external-directory `make check`
- six hostile mutations rejected
- exact diff, syntax, artifact, manifest, secret-pattern, conflict-marker, mode, and whitespace audits passed

## Risk

This is a documentation and contract-enforcement change; runtime and provider behavior are unchanged. Exact pins still require deliberate maintenance when security or compatibility releases are adopted.

## Follow-Ups

This PR is stacked on #17 and should be reviewed and merged after it. Live Wit.ai, Messenger, and OpenWeather API-version review remains a separate credential-backed task. No existing pull request is merged or closed.

## Post-Deploy Monitoring & Validation

Confirm the exact-head Python 3.10, 3.12, and 3.14 hosted jobs pass and code scanning reports no branch alert before merge.

---

Built with the Compound Engineering LFG workflow.
