### PR TITLE
fix: require Messenger verification mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-16
 
+- Required exact Messenger subscription verification mode before token and
+  challenge processing.
 - Verified support covers Python 3.10, 3.12, and 3.14 with Bottle 0.13.4, Requests 2.34.2, and WebTest 3.0.7 pinned exactly.
 - Replaced stale Wit response text with a stable retry-later message when a
   known-location OpenWeather lookup fails.

--- a/PROVIDER_SETUP.md
+++ b/PROVIDER_SETUP.md
@@ -29,9 +29,10 @@ https://<public-host>/webhook
 
 Both Messenger operations use `/webhook`:
 
-- `GET /webhook` handles subscription verification. Meta supplies
-  `hub.verify_token` and `hub.challenge`; Weatherbot returns the challenge as
-  plain text only when the configured verify token matches.
+- `GET /webhook` handles subscription verification. Meta supplies the exact
+  `hub.mode=subscribe`, `hub.verify_token`, and `hub.challenge`; Weatherbot
+  returns the challenge as plain text only when the mode and configured verify
+  token match.
 - `POST /webhook` handles events. It requires `Content-Type: application/json`,
   a valid `X-Hub-Signature-256` generated with `FB_APP_SECRET`, a body no larger
   than 1 MiB, and a top-level Messenger object of `page`.
@@ -67,8 +68,9 @@ without a separate security review.
 Record the commit SHA, review date, reviewer, public callback hostname, provider
 names, and pass/fail status for these checks:
 
-- GET verification succeeds with the matching verify token and rejects a
-  mismatched token without echoing the challenge.
+- GET verification succeeds with exact subscription mode and the matching
+  verify token, and rejects a missing or malformed mode or mismatched token
+  without echoing the challenge.
 - Unsigned, incorrectly signed, non-JSON, oversized, and non-page POST requests
   are rejected before Wit actions.
 - A synthetic signed event passes the offline route suite without real user

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - `WIT_TOKEN` configures Wit.ai access.
 - `FB_PAGE_TOKEN` configures Facebook Messenger replies.
 - `FB_VERIFY_TOKEN` configures Messenger webhook verification.
+- Messenger GET verification requires the exact `subscribe` verification mode
+  before the configured token and challenge are accepted.
 - `FB_APP_SECRET` validates `X-Hub-Signature-256` on Messenger POST payloads.
 - Messenger POST bodies are limited to 1 MiB before signature verification.
 - Expected Wit transport and response failures are isolated to the affected

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -63,6 +63,10 @@ Messenger webhook payloads should only invoke Wit actions when both the sender
 ID and message text are textual and nonblank. Malformed sender IDs should be
 acknowledged without creating a Wit session.
 
+GET challenges require the exact Messenger subscription verification mode
+before token and challenge processing; malformed intent must fail without
+echoing caller-controlled challenge text.
+
 Expected Wit transport and response failures are isolated to the affected
 event so they do not force retries of an authenticated Messenger batch after
 earlier replies may have been sent. Public errors and logs must not include

--- a/VISION.md
+++ b/VISION.md
@@ -21,6 +21,7 @@ Priority:
 - Reject blank Messenger message text before Wit action handling
 - Suppress retried Messenger message IDs before repeating Wit actions
 - Process Messenger message batches in order with a fixed per-webhook cap
+- Require exact Messenger subscription verification intent before challenges
 - Fail Messenger replies on provider HTTP errors so webhook retries remain
   recoverable
 - Isolate expected Wit failures per Messenger event to avoid batch retry

--- a/docs/plans/2026-06-16-messenger-verification-mode.md
+++ b/docs/plans/2026-06-16-messenger-verification-mode.md
@@ -1,0 +1,55 @@
+# Require Messenger Subscription Verification Mode
+
+Status: Planned
+
+## Context
+
+The Messenger GET webhook validates the configured verify token and requires a
+challenge, but it does not validate `hub.mode`. A request carrying the correct
+secret can therefore receive the verification challenge even when it is not an
+explicit subscription-verification request.
+
+## Requirements
+
+- Require `hub.mode` to equal `subscribe` before returning a challenge.
+- Fail closed for missing, non-text, differently cased, or whitespace-padded
+  mode values without echoing the challenge.
+- Preserve constant-time verify-token comparison, missing-challenge handling,
+  and the plain-text challenge response.
+- Add Bottle/WebTest and dependency-free regressions plus mutation-sensitive
+  static contracts and maintained provider guidance.
+- Keep POST webhook authentication and provider behavior unchanged.
+
+## Implementation Units
+
+### U1. Validate verification intent
+
+- **File:** `messenger.py`
+- Reject any GET verification request whose exact mode is not `subscribe`.
+
+### U2. Prove fail-closed behavior
+
+- **Files:** `test_messenger.py`, `scripts/check_weatherbot_contracts.py`
+- Cover accepted subscription verification and rejected missing or malformed
+  mode values, including checker registration and ordering contracts.
+
+### U3. Maintain operational guidance
+
+- **Files:** `PROVIDER_SETUP.md`, `README.md`, `SECURITY.md`, `VISION.md`,
+  `CHANGES.md`
+- Document the exact subscription-verification requirement.
+
+## Verification
+
+- Run focused route and dependency-free tests, then repository and external-
+  directory non-cleaning verification with explicit timeouts.
+- Reject mutations that remove or weaken mode validation, move it after token
+  or challenge handling, remove runtime/static coverage, weaken guidance, or
+  reopen the plan.
+- Audit exact paths, generated artifacts, conflicts, file modes, whitespace,
+  and credential-like additions before committing.
+
+## Runtime Boundary
+
+All verification requests are synthetic. No Meta, Wit.ai, OpenWeather, or live
+credential interaction is performed.

--- a/docs/plans/2026-06-16-messenger-verification-mode.md
+++ b/docs/plans/2026-06-16-messenger-verification-mode.md
@@ -1,6 +1,6 @@
 # Require Messenger Subscription Verification Mode
 
-Status: Planned
+Status: Completed
 
 ## Context
 
@@ -53,3 +53,28 @@ explicit subscription-verification request.
 
 All verification requests are synthetic. No Meta, Wit.ai, OpenWeather, or live
 credential interaction is performed.
+
+## Work Completed
+
+- Required exact `hub.mode=subscribe` before verify-token and challenge
+  processing.
+- Added Bottle/WebTest and dependency-free rejection coverage for missing,
+  differently cased, whitespace-padded, and non-text mode values.
+- Updated provider, security, roadmap, README, and change guidance plus the
+  completed-plan checker registration.
+
+## Verification Completed
+
+- Two focused Bottle/WebTest route tests passed in a fresh Python 3.12
+  environment with the repository's exact runtime and test pins.
+- The complete 31-test Bottle/WebTest suite passed in that environment.
+- Two focused dependency-free verification-mode contracts passed.
+- Repository and external-directory non-cleaning `make verify` are the full
+  gates for this change; both passed with 53 dependency-free contracts and 31
+  Bottle/WebTest tests. The broad-cleaning `make check` wrapper is not run
+  because workspace policy forbids broad generated-artifact deletion; its
+  verification payload is `make verify`.
+- Eight isolated mutations were rejected for removed or normalized mode
+  validation, token-before-mode ordering, successful invalid-mode status,
+  missing runtime coverage, missing checker registration, weakened guidance,
+  and reopened plan status.

--- a/messenger.py
+++ b/messenger.py
@@ -101,6 +101,10 @@ def messenger_webhook():
     A webhook to return a challenge
     """
     response.content_type = 'text/plain; charset=UTF-8'
+    if request.query.get('hub.mode') != 'subscribe':
+        response.status = 400
+        return 'Invalid verification mode'
+
     verify_token = request.query.get('hub.verify_token')
     # check whether the verify tokens match
     if not secure_compare(verify_token, FB_VERIFY_TOKEN):

--- a/scripts/check_weatherbot_contracts.py
+++ b/scripts/check_weatherbot_contracts.py
@@ -75,6 +75,9 @@ WEATHER_FAILURE_MESSAGE_PLAN_PATH = (
 VERSION_CONTRACT_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-16-python-dependency-version-contract.md"
 )
+MESSENGER_VERIFICATION_MODE_PLAN_PATH = (
+    ROOT / "docs" / "plans" / "2026-06-16-messenger-verification-mode.md"
+)
 
 
 class FakeBottle:
@@ -283,7 +286,7 @@ def test_messenger_verification_rejects_missing_configured_token():
     messenger, request, response, _requests, _calls = load_messenger()
 
     messenger.FB_VERIFY_TOKEN = None
-    request.query = {"hub.challenge": "challenge-1"}
+    request.query = {"hub.mode": "subscribe", "hub.challenge": "challenge-1"}
     response.status = 200
 
     body = messenger.messenger_webhook()
@@ -295,7 +298,11 @@ def test_messenger_verification_rejects_missing_configured_token():
 def test_messenger_verification_rejects_wrong_token():
     messenger, request, response, _requests, _calls = load_messenger()
 
-    request.query = {"hub.challenge": "challenge-1", "hub.verify_token": "wrong"}
+    request.query = {
+        "hub.mode": "subscribe",
+        "hub.challenge": "challenge-1",
+        "hub.verify_token": "wrong",
+    }
     response.status = 200
 
     body = messenger.messenger_webhook()
@@ -307,7 +314,11 @@ def test_messenger_verification_rejects_wrong_token():
 def test_messenger_verification_accepts_matching_token():
     messenger, request, response, _requests, _calls = load_messenger()
 
-    request.query = {"hub.challenge": "challenge-1", "hub.verify_token": "verify-token"}
+    request.query = {
+        "hub.mode": "subscribe",
+        "hub.challenge": "challenge-1",
+        "hub.verify_token": "verify-token",
+    }
     response.status = 200
 
     body = messenger.messenger_webhook()
@@ -320,13 +331,66 @@ def test_messenger_verification_accepts_matching_token():
 def test_messenger_verification_requires_challenge():
     messenger, request, response, _requests, _calls = load_messenger()
 
-    request.query = {"hub.verify_token": "verify-token"}
+    request.query = {"hub.mode": "subscribe", "hub.verify_token": "verify-token"}
     response.status = 200
 
     body = messenger.messenger_webhook()
 
     assert_equal(response.status, 400, "missing challenge status")
     assert_true(body != "challenge-1", "missing challenge must not echo challenge")
+
+
+def test_messenger_verification_rejects_invalid_modes():
+    messenger, request, response, _requests, _calls = load_messenger()
+
+    for mode in (None, "Subscribe", " subscribe ", ["subscribe"]):
+        request.query = {
+            "hub.verify_token": "verify-token",
+            "hub.challenge": "challenge-1",
+        }
+        if mode is not None:
+            request.query["hub.mode"] = mode
+        response.status = 200
+
+        body = messenger.messenger_webhook()
+
+        assert_equal(response.status, 400, "invalid verification mode status {0!r}".format(mode))
+        assert_equal(body, "Invalid verification mode", "invalid verification mode body {0!r}".format(mode))
+        assert_true(body != "challenge-1", "invalid verification mode must not echo challenge")
+
+
+def test_messenger_verification_mode_source_contracts():
+    source = (ROOT / "messenger.py").read_text(encoding="utf-8")
+    webhook_source = source.split("@app.get('/webhook')", 1)[1].split("def secure_compare", 1)[0]
+    runtime_tests = (ROOT / "test_messenger.py").read_text(encoding="utf-8")
+    for contract in (
+        "if request.query.get('hub.mode') != 'subscribe':",
+        "response.status = 400",
+        "return 'Invalid verification mode'",
+    ):
+        assert_true(contract in webhook_source, "missing Messenger verification-mode contract {0}".format(contract))
+
+    mode_guard = webhook_source.index("if request.query.get('hub.mode') != 'subscribe':")
+    token_read = webhook_source.index("verify_token = request.query.get('hub.verify_token')")
+    challenge_read = webhook_source.index("challenge = request.query.get('hub.challenge')")
+    assert_true(mode_guard < token_read < challenge_read, "Messenger verification mode must be checked before token and challenge processing")
+    assert_true(
+        "test_facebook_verification_requires_exact_subscribe_mode" in runtime_tests,
+        "runtime coverage must reject invalid Messenger verification modes",
+    )
+
+    docs = {
+        "README.md": "requires the exact `subscribe` verification mode",
+        "PROVIDER_SETUP.md": "`hub.mode=subscribe`",
+        "SECURITY.md": "exact Messenger subscription verification mode",
+        "VISION.md": "Require exact Messenger subscription verification intent",
+        "CHANGES.md": "Required exact Messenger subscription verification mode",
+    }
+    for relative_path, phrase in docs.items():
+        assert_true(
+            phrase in (ROOT / relative_path).read_text(encoding="utf-8"),
+            "{0} must document Messenger verification mode".format(relative_path),
+        )
 
 
 def test_messenger_post_ignores_non_message_events():
@@ -1135,6 +1199,7 @@ def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(MESSENGER_REPLY_HTTP_STATUS_PLAN_PATH, "weatherbot Messenger reply HTTP status")
     assert_completed_plan(WEATHER_FAILURE_MESSAGE_PLAN_PATH, "weatherbot weather failure user message")
     assert_completed_plan(VERSION_CONTRACT_PLAN_PATH, "weatherbot Python and dependency versions")
+    assert_completed_plan(MESSENGER_VERIFICATION_MODE_PLAN_PATH, "weatherbot Messenger verification mode")
     checker_main = Path(__file__).read_text().rsplit("def main():", 1)[1]
     assert_true(
         "test_provider_setup_guide_is_auditable," in checker_main,
@@ -1143,6 +1208,10 @@ def test_completed_plans_are_in_docs_plans():
     assert_true(
         "test_supported_version_guidance," in checker_main,
         "supported version guidance contract must run in the main suite",
+    )
+    assert_true(
+        "test_messenger_verification_mode_source_contracts," in checker_main,
+        "Messenger verification-mode contract must run in the main suite",
     )
 
 
@@ -1345,6 +1414,8 @@ def main():
         test_messenger_verification_rejects_wrong_token,
         test_messenger_verification_accepts_matching_token,
         test_messenger_verification_requires_challenge,
+        test_messenger_verification_rejects_invalid_modes,
+        test_messenger_verification_mode_source_contracts,
         test_messenger_post_ignores_non_message_events,
         test_messenger_post_ignores_echoes_and_continues_batch,
         test_messenger_post_ignores_malformed_nested_events_and_continues_batch,

--- a/test_messenger.py
+++ b/test_messenger.py
@@ -66,11 +66,25 @@ class TestMessenger(unittest.TestCase):
     def test_facebook_verification_challenge_is_plain_text(self):
         response = test_app.get(
             '/webhook?hub.challenge=%3Cscript%3Ealert(1)%3C%2Fscript%3E'
-            '&hub.verify_token=test-verify-token')
+            '&hub.verify_token=test-verify-token&hub.mode=subscribe')
 
         self.assertEqual(response.status_int, 200)
         self.assertEqual(response.text, '<script>alert(1)</script>')
         self.assertEqual(response.content_type, 'text/plain')
+
+    def test_facebook_verification_requires_exact_subscribe_mode(self):
+        invalid_queries = [
+            'hub.verify_token=test-verify-token&hub.challenge=123',
+            'hub.mode=Subscribe&hub.verify_token=test-verify-token&hub.challenge=123',
+            'hub.mode=%20subscribe%20&hub.verify_token=test-verify-token&hub.challenge=123',
+        ]
+
+        for query in invalid_queries:
+            with self.subTest(query=query):
+                response = test_app.get('/webhook?' + query, expect_errors=True)
+                self.assertEqual(response.status_int, 400)
+                self.assertEqual(response.text, 'Invalid verification mode')
+                self.assertNotEqual(response.text, self.challenge)
 
     def test_facebook_delivery_event_is_ignored(self):
         """


### PR DESCRIPTION
## Summary

Require exact Messenger subscription intent before reading the configured verification token or returning a caller-controlled challenge.

## Baseline

The route previously returned a challenge whenever the secret matched, even when the request did not explicitly identify subscription verification intent.

## Improvements

- require exact `hub.mode=subscribe` for Messenger GET verification
- reject missing, differently cased, padded, and non-text mode values before token or challenge processing
- add runtime, dependency-free, plan, and provider-guidance contracts

## Validation

- 53 dependency-free contracts
- 31 Bottle/WebTest tests in a fresh Python 3.12 environment with exact repository pins
- repository and external-directory `make verify`
- 8 isolated mutations rejected
- exact diff, artifact, secret, conflict, mode, whitespace, and upstream-parity audits
- exact head `511aeadf3f0d2d0b03b0f2cce1a487918f280595`: two hosted checks succeeded and one remained in progress at the bounded observation

## Risk

The branch is stacked on PR #18, one exact-head hosted check remains nonterminal, and validation used synthetic credential-free requests rather than live Meta, Wit.ai, or OpenWeather services.

## Follow-Ups

- confirm the remaining hosted check completes successfully
- review and land PR #18 before this stacked change
- retain provider configuration and live-service behavior as explicit external verification boundaries

## Why

The route previously returned a challenge whenever the secret matched, even when the request did not explicitly identify subscription verification intent.

## Runtime Boundary

All verification requests are synthetic and credential-free; no live Meta, Wit.ai, or OpenWeather request was made.
