### PR TITLE
Fix Wit reply text on Python 3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-16
 
+- Preserved normalized Unicode Wit replies through Messenger JSON serialization
+  and rejected missing, non-text, or blank reply values with a stable error.
 - Required exact Messenger subscription verification mode before token and
   challenge processing.
 - Verified support covers Python 3.10, 3.12, and 3.14 with Bottle 0.13.4, Requests 2.34.2, and WebTest 3.0.7 pinned exactly.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   Wit entity normalization, Messenger object validation, Messenger sender/text
   normalization, Messenger replay suppression and body size, OpenWeather shape,
   request timeout, outbound API, weather fallback, Wit failure-isolation, and
-  Wit log-privacy contract checks.
+  Unicode reply normalization, malformed reply rejection, and Wit log-privacy
+  contract checks.
 - `make check` runs `make verify` with bytecode cleanup before and after.
 - `python3 scripts/check_weatherbot_contracts.py` runs just the webhook and outbound API contracts.
 - Completed maintenance plans live under `docs/plans` and are checked by
@@ -79,6 +80,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - Expected Wit transport and response failures are isolated to the affected
   Messenger event so later messages in an authenticated batch still run and
   the valid webhook can be acknowledged.
+- Wit message replies remain normalized Unicode text through Messenger JSON
+  serialization; missing, non-text, and blank replies fail with a stable error.
 - Known-location weather lookup failures send a stable retry-later message
   instead of forwarding stale Wit forecast text or provider details.
 - Recent non-empty Messenger message IDs are claimed in a bounded process-local

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -71,6 +71,9 @@ Expected Wit transport and response failures are isolated to the affected
 event so they do not force retries of an authenticated Messenger batch after
 earlier replies may have been sent. Public errors and logs must not include
 tokens, sender IDs, message text, request URLs, or provider response bodies.
+Wit message replies must remain normalized Unicode text before Messenger JSON
+serialization; missing, non-text, and blank provider replies fail closed with
+the same stable error.
 
 ## Dependency and Supply Chain Security
 

--- a/VISION.md
+++ b/VISION.md
@@ -26,6 +26,8 @@ Priority:
   recoverable
 - Isolate expected Wit failures per Messenger event to avoid batch retry
   amplification after earlier replies
+- Preserve normalized Unicode Wit replies through Messenger JSON serialization
+- Reject missing, non-text, or blank Wit reply text with a stable error
 - Make weather lookup and response flow easy to trace
 - Treat malformed Wit entities as missing user location
 - Normalize flat and nested Wit location values before weather lookup

--- a/docs/plans/2026-06-16-wit-reply-text-normalization.md
+++ b/docs/plans/2026-06-16-wit-reply-text-normalization.md
@@ -1,6 +1,6 @@
 # Wit Reply Text Normalization
 
-## Status: Planned
+## Status: Completed
 
 ## Priority
 
@@ -65,4 +65,14 @@ therefore do not cover the actual Wit-to-Messenger boundary.
 
 ## Verification Completed
 
-Pending implementation and bounded verification.
+- The pre-fix action-loop reproduction produced `bytes` and Python's JSON
+  encoder raised `TypeError: Object of type bytes is not JSON serializable`.
+- Focused executable and dependency-free Wit reply tests passed for Unicode,
+  missing, bytes, numeric, and blank reply values.
+- Seven hostile Wit reply mutations were rejected across production
+  normalization, validation, executable/portable coverage, guidance, and plan
+  status.
+- Repository and external-directory `make check` passed in an isolated Python
+  3.12 environment with the exact runtime and test dependency pins.
+- Exact-path diff, generated-artifact, secret, conflict-marker, mode, binary,
+  large-file, and whitespace audits passed before commit.

--- a/docs/plans/2026-06-16-wit-reply-text-normalization.md
+++ b/docs/plans/2026-06-16-wit-reply-text-normalization.md
@@ -1,0 +1,68 @@
+# Wit Reply Text Normalization
+
+## Status: Planned
+
+## Priority
+
+P1 functional correctness. On every documented Python 3 runtime, the vendored
+Wit action loop converts a normal Unicode reply to `bytes` before calling the
+Messenger send action. Requests' JSON encoder cannot serialize bytes, so valid
+Wit message responses fail before Messenger delivery.
+
+## Problem
+
+`Wit.__run_actions()` calls `.encode('utf8')` on the provider's `msg` field.
+That was compatible with the repository's historical Python 2 origin but is
+incorrect under Python 3. The existing send tests inject strings directly and
+therefore do not cover the actual Wit-to-Messenger boundary.
+
+## Approach
+
+- Require Wit message replies to be nonblank text.
+- Preserve normalized Unicode text instead of producing bytes.
+- Raise the stable `WitError` for missing, non-text, or blank reply values.
+- Add executable tests that drive `Wit.run_actions()` into the real send action
+  and prove Unicode text remains JSON serializable.
+- Extend dependency-free contracts, guidance, changelog, and completed evidence.
+
+## Files
+
+- `wit.py`
+- `test_messenger.py`
+- `scripts/check_weatherbot_contracts.py`
+- `README.md`
+- `SECURITY.md`
+- `VISION.md`
+- `CHANGES.md`
+- `docs/plans/2026-06-16-wit-reply-text-normalization.md`
+
+## Verification
+
+- Preserve the pre-fix reproduction showing a bytes reply and JSON
+  serialization failure.
+- Run focused runtime tests and the full pinned package gate from the repository
+  and an external directory.
+- Reject mutations restoring byte encoding, accepting malformed replies,
+  weakening executable/static tests, drifting guidance, or leaving the plan
+  incomplete.
+- Audit exact paths, generated artifacts, secrets, conflict markers, modes,
+  binaries, large files, and whitespace.
+
+## Scope Boundaries
+
+- Do not change provider endpoints, credentials, API versions, action-loop
+  limits, webhook authentication, Messenger payload shape, weather behavior,
+  dependencies, or workflow configuration.
+- Do not make live Wit.ai, Messenger, or OpenWeather requests.
+- Keep PR #19 and its predecessors open and preserve base-first stack ordering.
+
+## Success Criteria
+
+- Valid Wit Unicode replies reach Messenger as `str` and serialize as JSON.
+- Missing, non-text, and blank Wit replies fail with the stable public
+  `WitError`.
+- Python 3.10, 3.12, and 3.14 hosted lanes retain the same contract.
+
+## Verification Completed
+
+Pending implementation and bounded verification.

--- a/scripts/check_weatherbot_contracts.py
+++ b/scripts/check_weatherbot_contracts.py
@@ -4,6 +4,7 @@ import importlib.util
 import hashlib
 import hmac
 import io
+import json
 import os
 import sys
 import types
@@ -77,6 +78,9 @@ VERSION_CONTRACT_PLAN_PATH = (
 )
 MESSENGER_VERIFICATION_MODE_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-16-messenger-verification-mode.md"
+)
+WIT_REPLY_TEXT_PLAN_PATH = (
+    ROOT / "docs" / "plans" / "2026-06-16-wit-reply-text-normalization.md"
 )
 
 
@@ -1030,6 +1034,74 @@ def test_wit_requests_use_timeout():
     assert_equal(kwargs.get("timeout"), 5, "wit request timeout")
 
 
+def test_wit_message_replies_remain_json_serializable_unicode():
+    load_messenger()
+    wit = sys.modules["wit"]
+    sent = []
+    responses = iter([
+        {"type": "msg", "msg": "  Prévisions prêtes  "},
+        {"type": "stop"},
+    ])
+    client = wit.Wit(
+        "wit-token",
+        actions={"send": lambda request, response: sent.append(response["text"])},
+    )
+    client.converse = lambda *_args, **_kwargs: next(responses)
+
+    client.run_actions("user-1", "weather")
+
+    assert_equal(sent, ["Prévisions prêtes"], "normalized Wit reply text")
+    assert_true(isinstance(sent[0], str), "Wit reply text must remain Unicode")
+    assert_equal(
+        json.loads(json.dumps({"text": sent[0]})),
+        {"text": "Prévisions prêtes"},
+        "Wit reply text JSON round trip",
+    )
+
+
+def test_wit_message_replies_reject_invalid_text():
+    load_messenger()
+    wit = sys.modules["wit"]
+    for invalid_text in (None, b"bytes", 42, "   "):
+        sent = []
+        client = wit.Wit(
+            "wit-token",
+            actions={"send": lambda request, response: sent.append(response)},
+        )
+        client.converse = lambda *_args, **_kwargs: {
+            "type": "msg",
+            "msg": invalid_text,
+        }
+        try:
+            client.run_actions("user-1", "weather")
+        except wit.WitError as error:
+            assert_equal(str(error), "Wit response was invalid.", "invalid Wit reply error")
+        else:
+            raise AssertionError("invalid Wit reply must raise WitError: {0!r}".format(invalid_text))
+        assert_equal(sent, [], "invalid Wit reply send calls")
+
+    source = (ROOT / "wit.py").read_text(encoding="utf-8")
+    runtime_tests = (ROOT / "test_messenger.py").read_text(encoding="utf-8")
+    assert_true("def normalized_message_text(value):" in source, "Wit replies must be normalized")
+    assert_true("json.get('msg').encode('utf8')" not in source, "Wit replies must not become bytes")
+    assert_true(
+        "test_wit_message_reply_remains_json_serializable_unicode" in runtime_tests,
+        "runtime tests must cover Unicode Wit replies",
+    )
+    documents = {
+        "README.md": "normalized Unicode text through Messenger JSON serialization",
+        "SECURITY.md": "normalized Unicode text before Messenger JSON serialization",
+        "VISION.md": "normalized Unicode Wit replies through Messenger JSON serialization",
+        "CHANGES.md": "normalized Unicode Wit replies through Messenger JSON serialization",
+    }
+    for relative_path, phrase in documents.items():
+        document = " ".join((ROOT / relative_path).read_text(encoding="utf-8").split())
+        assert_true(
+            phrase in document,
+            relative_path + " must document Wit reply text normalization",
+        )
+
+
 def test_wit_debug_logs_avoid_message_payloads():
     source = (ROOT / "wit.py").read_text()
     assert_true(
@@ -1200,6 +1272,7 @@ def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(WEATHER_FAILURE_MESSAGE_PLAN_PATH, "weatherbot weather failure user message")
     assert_completed_plan(VERSION_CONTRACT_PLAN_PATH, "weatherbot Python and dependency versions")
     assert_completed_plan(MESSENGER_VERIFICATION_MODE_PLAN_PATH, "weatherbot Messenger verification mode")
+    assert_completed_plan(WIT_REPLY_TEXT_PLAN_PATH, "weatherbot Wit reply text normalization")
     checker_main = Path(__file__).read_text().rsplit("def main():", 1)[1]
     assert_true(
         "test_provider_setup_guide_is_auditable," in checker_main,
@@ -1212,6 +1285,11 @@ def test_completed_plans_are_in_docs_plans():
     assert_true(
         "test_messenger_verification_mode_source_contracts," in checker_main,
         "Messenger verification-mode contract must run in the main suite",
+    )
+    assert_true(
+        "test_wit_message_replies_remain_json_serializable_unicode," in checker_main
+        and "test_wit_message_replies_reject_invalid_text," in checker_main,
+        "Wit reply text contracts must run in the main suite",
     )
 
 
@@ -1447,6 +1525,8 @@ def main():
         test_bottle_debug_is_disabled_by_default,
         test_bottle_debug_requires_truthy_env_flag,
         test_wit_requests_use_timeout,
+        test_wit_message_replies_remain_json_serializable_unicode,
+        test_wit_message_replies_reject_invalid_text,
         test_wit_debug_logs_avoid_message_payloads,
         test_wit_failures_use_stable_public_errors,
         test_first_entity_value_handles_malformed_entities,

--- a/test_messenger.py
+++ b/test_messenger.py
@@ -444,6 +444,45 @@ class TestMessenger(unittest.TestCase):
 
         self.assertEqual(str(raised.exception), 'Wit responded with an error.')
 
+    def test_wit_message_reply_remains_json_serializable_unicode(self):
+        sent = []
+        responses = iter([
+            {'type': 'msg', 'msg': '  Prévisions prêtes  '},
+            {'type': 'stop'},
+        ])
+        client = wit.Wit(
+            'test-token',
+            actions={'send': lambda request, response: sent.append(response['text'])},
+        )
+        client.converse = lambda *_args, **_kwargs: next(responses)
+
+        client.run_actions(self.user_id, 'weather')
+
+        self.assertEqual(sent, ['Prévisions prêtes'])
+        self.assertIsInstance(sent[0], str)
+        self.assertEqual(
+            json.loads(json.dumps({'text': sent[0]})),
+            {'text': 'Prévisions prêtes'},
+        )
+
+    def test_wit_message_reply_rejects_invalid_text(self):
+        for invalid_text in (None, b'bytes', 42, '   '):
+            with self.subTest(invalid_text=invalid_text):
+                sent = []
+                client = wit.Wit(
+                    'test-token',
+                    actions={'send': lambda request, response: sent.append(response)},
+                )
+                client.converse = lambda *_args, **_kwargs: {
+                    'type': 'msg',
+                    'msg': invalid_text,
+                }
+
+                with self.assertRaisesRegex(wit.WitError, 'Wit response was invalid'):
+                    client.run_actions(self.user_id, 'weather')
+
+                self.assertEqual(sent, [])
+
     def test_facebook_response(self):
         """
         A test to send a FB message test

--- a/wit.py
+++ b/wit.py
@@ -29,6 +29,16 @@ class WitError(Exception):
     pass
 
 
+def normalized_message_text(value):
+    if not isinstance(value, str):
+        raise WitError('Wit response was invalid.')
+
+    value = value.strip()
+    if not value:
+        raise WitError('Wit response was invalid.')
+    return value
+
+
 def req(logger, access_token, meth, path, params, **kwargs):
     full_url = WIT_API_HOST + path
     logger.debug('%s %s request', meth, full_url)
@@ -141,7 +151,7 @@ class Wit:
         if json['type'] == 'msg':
             self.throw_if_action_missing('send')
             response = {
-                'text': json.get('msg').encode('utf8'),
+                'text': normalized_message_text(json.get('msg')),
                 'quickreplies': json.get('quickreplies'),
             }
             self.actions['send'](request, response)


### PR DESCRIPTION
## Summary

Keep normal Wit message replies as Unicode text on Python 3 so Requests can
serialize them into Messenger JSON payloads.

## Baseline

The vendored Wit action loop called `.encode('utf8')` on provider reply text.
On Python 3 this produced `bytes`, and Messenger JSON serialization raised
`TypeError: Object of type bytes is not JSON serializable`.

## Improvements

- Normalize valid Wit replies to trimmed Python `str` values.
- Reject missing, bytes, numeric, and blank replies with the existing stable
  `WitError` before the send action runs.
- Exercise the real `Wit.run_actions()` message path in executable and
  dependency-free suites.
- Extend guidance, changelog, static contracts, and completed plan evidence.

## Validation

- Repository and hostile external-root `make check`: passed in an isolated
  Python 3.12.8 environment.
- Dependency-free contracts: 55 passed.
- Bottle/WebTest suite: 33 passed.
- Seven hostile mutations: all rejected.
- All 35 installed packages passed `uv pip check`; installed-site-packages
  `pip-audit` found no known vulnerabilities.
- Exact diff, artifact, secret, conflict, mode, binary, size, and whitespace
  audits: passed.

## Risk

Low. The change restores the Python 3 text type expected by Requests and narrows
malformed provider replies to an existing stable error. Provider endpoints,
credentials, API versions, action limits, and Messenger payload shape remain
unchanged.

## Stack Integration Boundary

CodeQL alert #1 (`py/reflective-xss`) remains open on `master` at commit
`8df8a0f`. This stacked head inherits the mitigation: Messenger verification
requires exact mode and token checks before returning the challenge as
`text/plain`. Alert closure still requires base-first stack integration and a
default-branch CodeQL rerun. Legacy PR #7 remains conflicting and is not part
of this stack.

## Follow-Ups

No live Wit.ai or Messenger request was made. Keep this PR stacked on PR #19
and merge the stack base-first. Python 3.10, 3.12, and 3.14 hosted checks are
green at exact head `826740e9e8c4a53bd1d21eec77b2a3b4638a7fa4`.
