### PR TITLE
Harden Messenger verification challenge headers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-19
 
+- Added anti-sniff and restrictive content-security headers to the exact
+  plain-text Messenger verification challenge response.
 - Rejected non-ASCII Messenger verification tokens with HTTP 403 instead of
   raising from constant-time comparison.
 - Counted only newly claimed Messenger messages toward the 20-message webhook

--- a/messenger.py
+++ b/messenger.py
@@ -101,6 +101,9 @@ def messenger_webhook():
     A webhook to return a challenge
     """
     response.content_type = 'text/plain; charset=UTF-8'
+    response.set_header('X-Content-Type-Options', 'nosniff')
+    response.set_header(
+        'Content-Security-Policy', "default-src 'none'; sandbox")
     if request.query.get('hub.mode') != 'subscribe':
         response.status = 400
         return 'Invalid verification mode'

--- a/scripts/check_weatherbot_contracts.py
+++ b/scripts/check_weatherbot_contracts.py
@@ -109,6 +109,10 @@ class MutableResponse:
     def __init__(self):
         self.status = 200
         self.content_type = None
+        self.headers = {}
+
+    def set_header(self, name, value):
+        self.headers[name] = value
 
 
 class FakeHTTPResponse:
@@ -349,6 +353,16 @@ def test_messenger_verification_accepts_matching_token():
     assert_equal(body, "challenge-1", "matching verify token challenge")
     assert_equal(response.status, 200, "matching verify token status")
     assert_equal(response.content_type, "text/plain; charset=UTF-8", "verification challenge content type")
+    assert_equal(
+        response.headers.get("X-Content-Type-Options"),
+        "nosniff",
+        "verification challenge anti-sniff header",
+    )
+    assert_equal(
+        response.headers.get("Content-Security-Policy"),
+        "default-src 'none'; sandbox",
+        "verification challenge content security policy",
+    )
 
 
 def test_messenger_verification_requires_challenge():
@@ -390,6 +404,8 @@ def test_messenger_verification_mode_source_contracts():
         "if request.query.get('hub.mode') != 'subscribe':",
         "response.status = 400",
         "return 'Invalid verification mode'",
+        "response.set_header('X-Content-Type-Options', 'nosniff')",
+        "'Content-Security-Policy', \"default-src 'none'; sandbox\"",
     ):
         assert_true(contract in webhook_source, "missing Messenger verification-mode contract {0}".format(contract))
 

--- a/test_messenger.py
+++ b/test_messenger.py
@@ -71,6 +71,10 @@ class TestMessenger(unittest.TestCase):
         self.assertEqual(response.status_int, 200)
         self.assertEqual(response.text, '<script>alert(1)</script>')
         self.assertEqual(response.content_type, 'text/plain')
+        self.assertEqual(response.headers['X-Content-Type-Options'], 'nosniff')
+        self.assertEqual(
+            response.headers['Content-Security-Policy'],
+            "default-src 'none'; sandbox")
 
     def test_facebook_verification_requires_exact_subscribe_mode(self):
         invalid_queries = [


### PR DESCRIPTION
## Summary

Adds browser-enforced defenses to the provider-required Messenger challenge echo.

## Baseline

Post-merge CodeQL continued to flag the exact verification challenge response as reflective XSS.

## Improvements

Preserves the required plain-text echo while adding anti-sniff and restrictive content-security headers plus regressions.

## Validation

The original description records the supported-runtime matrix, 57 contracts, 37 runtime tests, mutation proof, and diff hygiene.

## Risk

The raw challenge must remain an exact provider echo; static taint analysis may continue to report that intentional boundary.

## Follow-Ups

Retain exact mode/token verification and defensive response headers when changing the webhook contract.

## Original Description

<details>
<summary>Preserved verbatim</summary>

## Summary

Hardens the exact Messenger verification challenge echo with browser-enforced response headers after post-merge CodeQL continued to report the provider-mandated raw echo as reflective XSS.

## Change

- Keep the required exact `hub.challenge` text echo.
- Keep `text/plain; charset=UTF-8`.
- Add `X-Content-Type-Options: nosniff`.
- Add `Content-Security-Policy: default-src 'none'; sandbox`.
- Add runtime and dependency-free regression coverage.

Meta's official Messenger sample also returns `hub.challenge` unchanged after mode/token verification:
https://github.com/fbsamples/messenger-platform-samples/blob/cc87d98775965f21e10ad42a619c057501774af9/messenger-api/messenger-api-and-webhooks/app.py#L34-L45

## Evidence

- Red-first header regression reproduced missing browser defenses.
- `make check` passes on Python 3.10.16, 3.12.9, and 3.14.5.
- 57 dependency-free contracts and 37 Bottle/WebTest tests pass.
- Removing the two headers is killed by the focused regression.
- `git diff --check` passes.

## CodeQL boundary

If `py/reflective-xss` remains after this merge, it is a taint-only false positive: the value must be echoed exactly for provider verification, is gated by exact mode and constant-time token checks, and is rendered as plain text with anti-sniff and restrictive CSP headers.


</details>