### PR TITLE
docs: fix agent dependency setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@
 
 ## Development commands
 
-- Install dependencies: `python3 -m pip install -r requirements.txt`
+- Install dependencies: `python3 -m pip install -r requirements.txt -r test-requirements.txt`
 - Full baseline: `make check`
 - Combined verification: `make verify`
 - Lint/static checks: `make lint`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 2026-06-20
+
+- Corrected the agent setup command to install the pinned WebTest dependency
+  required by `make check`.
+- Added a regression contract that keeps agent guidance aligned with the
+  runtime and test dependency manifests.
+
 ## 2026-06-19
 
 - Added anti-sniff and restrictive content-security headers to the exact

--- a/docs/plans/2026-06-20-agent-test-dependency-guidance.md
+++ b/docs/plans/2026-06-20-agent-test-dependency-guidance.md
@@ -1,0 +1,25 @@
+# Agent Test Dependency Guidance
+
+## Status
+
+Completed on 2026-06-20.
+
+## Problem
+
+`AGENTS.md` documented installing only `requirements.txt`, but the repository's
+`make check` gate imports WebTest from `test-requirements.txt`. A clean
+environment following the agent instructions therefore could not run the
+documented verification command.
+
+## Change
+
+- Update the agent setup command to install both runtime and test requirements.
+- Extend the dependency contract so future guidance cannot omit the test
+  dependency manifest.
+
+## Verification
+
+- Run the contract once before the guidance fix and confirm it fails.
+- Run `make check` in a clean Python environment after the fix.
+- Repeat the gate from an external working directory with a hostile `ROOT`
+  override.

--- a/scripts/check_weatherbot_contracts.py
+++ b/scripts/check_weatherbot_contracts.py
@@ -1420,6 +1420,11 @@ def test_provider_setup_guide_is_auditable():
 
 
 def test_runtime_dependencies_and_ci_are_pinned():
+    agent_guidance = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    assert_true(
+        "python3 -m pip install -r requirements.txt -r test-requirements.txt" in agent_guidance,
+        "agent setup guidance must install runtime and test dependencies",
+    )
     gitignore = (ROOT / ".gitignore").read_text(encoding="utf-8")
     for pattern in ["!.github/", "!.github/workflows/", "!.github/workflows/*.yml"]:
         assert_true(pattern in gitignore, "workflow ignore exception: " + pattern)


### PR DESCRIPTION
## Summary

Make the agent-facing setup command install the pinned test dependency required by Weatherbot's documented verification gate.

## Baseline

`AGENTS.md` installed only `requirements.txt`, while `make check` imports WebTest from `test-requirements.txt`. A fresh environment following those instructions failed before the route tests could run.

## Improvements

- Update the agent setup command to install runtime and test requirements.
- Add a dependency contract that prevents the agent guidance from drifting again.
- Record the focused maintenance decision and validation procedure.

## Validation

- New contract failed before the guidance correction.
- Clean Python 3.12.8 environment installed both pinned manifests.
- Repository-root `make check`: 57 contracts and 37 route tests passed.
- External-directory `make check ROOT=/nonexistent`: same complete gate passed.
- `pip check`: passed.
- `pip-audit` across both manifests: no known vulnerabilities; the non-PyPI WebOb build remains explicitly unauditable.
- `git diff --check`: passed.

## Risk

Documentation and its static regression contract only. Runtime behavior is unchanged.

## Follow-Ups

- Keep runtime and test dependency manifests separate so production installs do not include WebTest.
