### PR TITLE
ci: prevent checkout credential persistence

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-21
+
+- Bound checkout credential isolation to the immutable checkout step and added
+  hostile contract mutations for missing, writable, and decoy-only settings.
+
 ## 2026-06-20
 
 - Corrected the agent setup command to install the pinned WebTest dependency

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,9 @@
 
 ## 2026-06-21
 
-- Bound checkout credential isolation to the immutable checkout step and added
-  hostile contract mutations for missing, writable, and decoy-only settings.
+- Bound checkout credential isolation to the only immutable checkout step and
+  added hostile contract mutations for missing, writable, decoy-only,
+  duplicate, and additional-checkout settings.
 
 ## 2026-06-20
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ When the required SDK or runtime is unavailable, use static checks and source re
 
 ## Security and Privacy Notes
 
+- Hosted verification checks out source without persisting Git credentials.
 - Review changes touching authentication or token handling; examples from the scan include messenger.py, wit.py.
 - Review changes touching external API calls or credential-adjacent configuration; examples from the scan include messenger.py, wit.py.
 - Review changes touching network requests, sockets, or service endpoints; examples from the scan include messenger.py, wit.py.

--- a/docs/plans/2026-06-21-checkout-credential-isolation.md
+++ b/docs/plans/2026-06-21-checkout-credential-isolation.md
@@ -1,0 +1,24 @@
+# Hosted Checkout Credential Isolation
+
+Status: Completed
+
+## Problem
+
+The hosted workflow used a read-only repository token but allowed
+`actions/checkout` to persist that token in local Git configuration. Later
+steps do not need Git authentication, so retaining the credential widened the
+impact of a compromised dependency or test process.
+
+## Change
+
+- Set `persist-credentials: false` on the immutable-pinned checkout step.
+- Bind the setting to the checkout step in the dependency-free repository
+  contract.
+- Reject missing, writable, and decoy-only credential settings.
+
+## Verification Results
+
+- The full pinned `make check` gate passed from the repository root and an
+  external working directory.
+- The checkout-isolation contract rejected all three hostile mutations.
+- No provider credential was loaded and no live provider request was sent.

--- a/docs/plans/2026-06-21-checkout-credential-isolation.md
+++ b/docs/plans/2026-06-21-checkout-credential-isolation.md
@@ -14,11 +14,13 @@ impact of a compromised dependency or test process.
 - Set `persist-credentials: false` on the immutable-pinned checkout step.
 - Bind the setting to the checkout step in the dependency-free repository
   contract.
-- Reject missing, writable, and decoy-only credential settings.
+- Reject missing, writable, decoy-only, duplicate, and additional-checkout
+  credential settings.
 
 ## Verification Results
 
 - The full pinned `make check` gate passed from the repository root and an
   external working directory.
-- The checkout-isolation contract rejected all three hostile mutations.
+- The checkout-isolation contract rejected all five hostile mutations,
+  including a second checkout and a duplicate key that could override `false`.
 - No provider credential was loaded and no live provider request was sent.

--- a/scripts/check_weatherbot_contracts.py
+++ b/scripts/check_weatherbot_contracts.py
@@ -14,6 +14,11 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+CHECKOUT_CREDENTIAL_ISOLATION_BLOCK = """      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false"""
 WEBHOOK_API_PLAN_PATH = ROOT / "docs" / "plans" / "2026-06-08-weatherbot-webhook-api-hardening.md"
 VERIFY_TOKEN_PLAN_PATH = ROOT / "docs" / "plans" / "2026-06-08-weatherbot-verify-token-fails-closed.md"
 WIT_ENTITY_PLAN_PATH = ROOT / "docs" / "plans" / "2026-06-08-weatherbot-wit-entity-shape.md"
@@ -255,6 +260,30 @@ def assert_equal(actual, expected, label):
 def assert_true(condition, label):
     if not condition:
         raise AssertionError(label)
+
+
+def checkout_credentials_are_isolated(workflow):
+    return workflow.count(CHECKOUT_CREDENTIAL_ISOLATION_BLOCK) == 1
+
+
+def test_checkout_credentials_are_isolated():
+    canonical = CHECKOUT_CREDENTIAL_ISOLATION_BLOCK
+    assert_true(checkout_credentials_are_isolated(canonical), "canonical checkout isolation")
+    assert_true(
+        not checkout_credentials_are_isolated(canonical.replace("false", "true")),
+        "writable checkout credentials must be rejected",
+    )
+    assert_true(
+        not checkout_credentials_are_isolated(canonical.replace("        with:\n", "")),
+        "missing checkout with block must be rejected",
+    )
+    assert_true(
+        not checkout_credentials_are_isolated(
+            canonical.replace("          persist-credentials: false", "")
+            + "\n      - run: echo 'persist-credentials: false'"
+        ),
+        "credential-isolation text outside checkout must be rejected",
+    )
 
 
 def test_messenger_post_rejects_invalid_json_shape():
@@ -1445,6 +1474,10 @@ def test_runtime_dependencies_and_ci_are_pinned():
     )
     assert_true(not (ROOT / "runtime.txt").exists(), "deprecated runtime.txt must remain removed")
     workflow = (ROOT / ".github" / "workflows" / "check.yml").read_text(encoding="utf-8")
+    assert_true(
+        checkout_credentials_are_isolated(workflow),
+        "checkout must disable persisted credentials exactly once",
+    )
     for contract in [
         "permissions:\n  contents: read",
         "concurrency:",
@@ -1454,7 +1487,6 @@ def test_runtime_dependencies_and_ci_are_pinned():
         'python-version: ["3.10", "3.12", "3.14"]',
         "workflow_dispatch:",
         "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10",
-        "persist-credentials: false",
         "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405",
         "python -m pip install --requirement requirements.txt --requirement test-requirements.txt",
         "run: make check",
@@ -1571,6 +1603,7 @@ def test_messenger_post_rejects_non_json_content_types_before_authentication():
 
 def main():
     tests = [
+        test_checkout_credentials_are_isolated,
         test_messenger_post_rejects_oversized_declared_body,
         test_messenger_post_rejects_oversized_streamed_body,
         test_messenger_post_accepts_json_content_type_parameters,

--- a/scripts/check_weatherbot_contracts.py
+++ b/scripts/check_weatherbot_contracts.py
@@ -1454,6 +1454,7 @@ def test_runtime_dependencies_and_ci_are_pinned():
         'python-version: ["3.10", "3.12", "3.14"]',
         "workflow_dispatch:",
         "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10",
+        "persist-credentials: false",
         "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405",
         "python -m pip install --requirement requirements.txt --requirement test-requirements.txt",
         "run: make check",

--- a/scripts/check_weatherbot_contracts.py
+++ b/scripts/check_weatherbot_contracts.py
@@ -19,6 +19,8 @@ CHECKOUT_CREDENTIAL_ISOLATION_BLOCK = """      - name: Check out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false"""
+CHECKOUT_ACTION_REFERENCE = "actions/checkout@"
+CHECKOUT_CREDENTIAL_SETTING = "persist-credentials:"
 WEBHOOK_API_PLAN_PATH = ROOT / "docs" / "plans" / "2026-06-08-weatherbot-webhook-api-hardening.md"
 VERIFY_TOKEN_PLAN_PATH = ROOT / "docs" / "plans" / "2026-06-08-weatherbot-verify-token-fails-closed.md"
 WIT_ENTITY_PLAN_PATH = ROOT / "docs" / "plans" / "2026-06-08-weatherbot-wit-entity-shape.md"
@@ -263,7 +265,11 @@ def assert_true(condition, label):
 
 
 def checkout_credentials_are_isolated(workflow):
-    return workflow.count(CHECKOUT_CREDENTIAL_ISOLATION_BLOCK) == 1
+    return (
+        workflow.count(CHECKOUT_CREDENTIAL_ISOLATION_BLOCK) == 1
+        and workflow.count(CHECKOUT_ACTION_REFERENCE) == 1
+        and workflow.count(CHECKOUT_CREDENTIAL_SETTING) == 1
+    )
 
 
 def test_checkout_credentials_are_isolated():
@@ -283,6 +289,24 @@ def test_checkout_credentials_are_isolated():
             + "\n      - run: echo 'persist-credentials: false'"
         ),
         "credential-isolation text outside checkout must be rejected",
+    )
+    assert_true(
+        not checkout_credentials_are_isolated(
+            canonical
+            + "\n      - uses: actions/checkout@"
+            + "df4cb1c069e1874edd31b4311f1884172cec0e10"
+        ),
+        "a second checkout without isolation must be rejected",
+    )
+    assert_true(
+        not checkout_credentials_are_isolated(
+            canonical.replace(
+                "          persist-credentials: false",
+                "          persist-credentials: false\n"
+                "          persist-credentials: true",
+            )
+        ),
+        "duplicate credential settings must be rejected",
     )
 
 


### PR DESCRIPTION
## Summary

Prevents GitHub Actions checkout credentials from persisting in the verification job.

## Baseline

The read-only workflow token remained available through checkout’s default credential persistence despite no later authenticated Git operation.

## Improvements

Sets `persist-credentials: false` and adds fail-closed contracts for duplicate, decoy, and additional checkout configurations.

## Validation

The original description records 58 structural contracts, 37 webhook tests, local Python 3.14 checks, actionlint, diff hygiene, and Gitleaks evidence.

## Risk

The job token still exists in the Actions environment for the job lifetime; this change removes Git credential persistence only.

## Follow-Ups

Hosted matrix and CodeQL evidence are reconciled independently against the merged exact head.

## Original Description

<details>
<summary>Preserved verbatim</summary>

## Summary

Prevent the read-only GitHub Actions token from remaining in the checkout, and bind that guarantee to the repository's only immutable checkout step with fail-closed hostile mutations.

## Deep review

**Bug:** `actions/checkout` used the default credential persistence behavior even though later verification steps do not need Git authentication. A compromised dependency or test process could therefore reuse the workflow token for the remainder of the job.

**Cause:** The Python 3 CI workflow introduced in `8e3a9a39` pinned checkout and limited the token to `contents: read`, but did not set `persist-credentials: false`. The first proposed contract also had two false greens: it accepted a second credential-persisting checkout and a duplicate YAML key that could override `false`.

**Provenance:** Credential persistence was introduced by `8e3a9a39` on June 10, 2026. The incomplete exact-block contract was introduced by this PR and repaired before merge in `c2ead4b3`.

**Best fix:** Disable persistence on the pinned checkout and require exactly one checkout reference and one credential setting, both represented by the canonical isolated checkout block. This keeps the gate dependency-free and fails closed if another checkout or duplicate setting is added.

**Refactor:** No broader workflow rewrite is warranted. The job has one checkout and no later authenticated Git operation; a focused ownership-boundary contract is clearer and lower risk.

## Changes

- Set `persist-credentials: false` on the SHA-pinned `actions/checkout` step.
- Require the canonical isolated checkout block exactly once.
- Reject missing, writable, decoy-only, duplicate, and additional-checkout settings.
- Document the security boundary and verification evidence.

## Proof

- 58 dependency-free structural and hostile-mutation contracts pass.
- 37 webhook tests pass with pinned runtime/test dependencies.
- Root and external-working-directory `make check` pass on Python 3.14 locally.
- Actionlint, diff hygiene, and changed-commit Gitleaks pass.
- The pre-repair contract accepted a second checkout and duplicate overriding key; the repaired exact-head contract rejects both.
- No provider credential was loaded and no live provider request was sent.

## Residual risk

- `contents: read` remains available to later steps through the Actions environment for the job lifetime; this change removes checkout persistence, not the token itself.
- Hosted Python 3.10/3.12/3.14 and CodeQL results must pass on exact head before merge.


</details>